### PR TITLE
NestedListWeightSum2 with HashMap

### DIFF
--- a/src/main/java/algorithms/curated170/medium/NestedListWeightSum2HashMap.java
+++ b/src/main/java/algorithms/curated170/medium/NestedListWeightSum2HashMap.java
@@ -1,0 +1,37 @@
+package algorithms.curated170.medium;
+
+import java.util.HashMap;
+import java.util.List;
+
+class NestedIntegerWeightSum2Hashmap {
+    HashMap<Integer, Integer> deepSumMap = new HashMap<>();
+    int max = 1;
+
+    public int depthSumInverse(List<NestedInteger> nestedList) {
+        maxDepth(nestedList, 1);
+        return sumMapTotal();
+    }
+
+    private void maxDepth(List<NestedInteger> nInt, int depth) {
+        for (NestedInteger nestedInteger : nInt) {
+            if (nestedInteger.isInteger()) {
+                deepSumMap.put(depth, deepSumMap.get(depth)+nestedInteger.getInteger());
+                max = Math.max(depth, max);
+            } else
+                maxDepth(nestedInteger.getList(), depth + 1);
+        }
+    }
+
+    private int sumMapTotal() {
+        int total = 0;
+        for(int i : deepSumMap.keySet())
+        {
+            total += deepSumMap.get(i) * (max-i+1);
+        }
+        return total;
+    }
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/NestedListWeightSum2HashMap.java
+++ b/src/main/java/algorithms/curated170/medium/NestedListWeightSum2HashMap.java
@@ -15,7 +15,7 @@ class NestedIntegerWeightSum2Hashmap {
     private void maxDepth(List<NestedInteger> nInt, int depth) {
         for (NestedInteger nestedInteger : nInt) {
             if (nestedInteger.isInteger()) {
-                deepSumMap.put(depth, deepSumMap.get(depth)+nestedInteger.getInteger());
+                deepSumMap.put(depth, deepSumMap.getOrDefault(depth, 0)+nestedInteger.getInteger());
                 max = Math.max(depth, max);
             } else
                 maxDepth(nestedInteger.getList(), depth + 1);


### PR DESCRIPTION
In this solution, in addition to keeping track of the maximum depth of the nested integers, we also sum individual layers and store these in a map. At the end, instead of re-looping through the nested integers, we just add the layer-sums elements in the map with their distance from the maximum depth.