### PR TITLE
1428. Leftmost Column with at Least a One

### DIFF
--- a/src/main/java/algorithms/curated170/medium/BinaryMatrix.java
+++ b/src/main/java/algorithms/curated170/medium/BinaryMatrix.java
@@ -1,0 +1,12 @@
+package algorithms.curated170.medium;
+ 
+import java.util.List;
+
+/**
+ *
+ * @author Altay
+ */
+public interface BinaryMatrix {
+      public int get(int row, int col); 
+      public List<Integer> dimensions();
+}

--- a/src/main/java/algorithms/curated170/medium/BinaryMatrixImplement.java
+++ b/src/main/java/algorithms/curated170/medium/BinaryMatrixImplement.java
@@ -1,0 +1,24 @@
+package algorithms.curated170.medium;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BinaryMatrixImplement implements BinaryMatrix {
+
+    int[][] mat = {{0,0},
+                   {0,1}};
+
+    @Override
+    public int get(int row, int col) {
+        return mat[row][col];
+    }
+
+    @Override
+    public List<Integer> dimensions() {
+        List dimensions = new ArrayList<Integer>();
+        dimensions.add(mat.length);
+        dimensions.add(mat[0].length);
+        return dimensions;
+    }
+
+}

--- a/src/main/java/algorithms/curated170/medium/LeftmostColumnwithatLeastaOne.java
+++ b/src/main/java/algorithms/curated170/medium/LeftmostColumnwithatLeastaOne.java
@@ -1,0 +1,65 @@
+package algorithms.curated170.medium;
+
+import java.util.List;
+
+public class LeftmostColumnwithatLeastaOne {
+
+    public static void main(String[] args) {
+        LeftmostColumnwithatLeastaOne l = new LeftmostColumnwithatLeastaOne();
+        int output = l.leftMostColumnWithOne(new BinaryMatrixImplement());
+        System.out.println(output);
+    }
+
+    //Row-First solution
+    public int leftMostColumnWithOne(BinaryMatrix binaryMatrix) {
+        List<Integer> dimensions = binaryMatrix.dimensions();
+        int m = dimensions.get(0);
+        int n = dimensions.get(1);
+        int currentResult = n;
+
+        for (int row = 0; row < m; row++) {
+            int high = n - 1;
+            int low = 0;
+
+            while (low < high) {
+                int mid = (low + high) / 2;
+
+                if (binaryMatrix.get(row, mid) == 0) {
+
+                    low = mid + 1;
+
+                } else {
+
+                    high = mid;
+
+                }
+            }
+            if (binaryMatrix.get(row, low) == 1) {
+                currentResult = Math.min(low, currentResult);
+            }
+        }
+        return currentResult == n ? -1 : currentResult;
+
+    }
+
+    //Col-first solution
+    public int leftMostColumnWithOneColFirst(BinaryMatrix binaryMatrix) {
+
+        List<Integer> dimensions = binaryMatrix.dimensions();
+        int m = dimensions.get(0);
+        int n = dimensions.get(1);
+
+        int currentRow = 0;
+        int currentCol = n - 1;
+        while (currentRow < m && currentCol >= 0) {
+
+            if (binaryMatrix.get(currentRow, currentCol) == 0) {
+                currentRow++;
+
+            } else {
+                currentCol--;
+            }
+        }
+        return currentCol == n - 1 ? -1 : currentCol + 1;
+    }
+}


### PR DESCRIPTION
(Refer to: https://github.com/spiralgo/algorithms/issues/54)

We can use either the row-first approach or the col-first approach for the solution.
Both would have almost the same efficiency. (0 ms.)
It is why I add both implementations.

For the row-first approach, we should consider that rows are sorted in a "non-decreasing" order.
It means we can employ Binary Search here.

For Binary Search we could look for _**"if (binaryMatrix.get(currentRow, currentCol) == 1)"**_  instead of _**if (binaryMatrix.get(currentRow, currentCol) == 0)**_
 But in this case, as far as I roughly think, we would have to use "Math.min()" in every iteration of while to reset currentResult until we find the smallest index.
 
For the col-first approach, we just increase the row number or decrease the column number (starting from the first row and the last column.) until we find the minimum index.