### PR TITLE
510. Inorder Successor in BST II

### DIFF
--- a/src/main/java/algorithms/curated170/medium/InorderSuccessorInBST2.java
+++ b/src/main/java/algorithms/curated170/medium/InorderSuccessorInBST2.java
@@ -2,24 +2,24 @@ package algorithms.curated170.medium;
 
 public class InorderSuccessorInBST2 {
 
-    public Node sucNode(Node start) {
+    public Node inorderSuccessor(Node start) {
         if (start == null) {
             return null;
         }
-        if (start.right == null) {
-            while (start.parent != null) {
-                if (start.parent.left == start) {
-                    return start.parent;
-                }
-                start = start.parent;
-            }
-            return null;
+        if (start.right != null)
+            return findIS(start.right);
+
+        while (start.parent != null && start.parent.left != start) {
+
+            start = start.parent;
         }
-        return findSuc(start);
+
+        return start.parent;
+
     }
 
-    private Node findSuc(Node n) {
-        return n.left == null ? n : findSuc(n.left);
+    private Node findIS(Node n) {
+        return n.left == null ? n : findIS(n.left);
     }
 
     private class Node {

--- a/src/main/java/algorithms/curated170/medium/InorderSuccessorInBST2.java
+++ b/src/main/java/algorithms/curated170/medium/InorderSuccessorInBST2.java
@@ -1,0 +1,47 @@
+package algorithms.curated170.medium;
+
+public class InorderSuccessorInBST2 {
+
+    public Node sucNode(Node start) {
+        if (start == null) {
+            return null;
+        }
+        if (start.right == null) {
+            while (start.parent != null) {
+                if (start.parent.left == start) {
+                    return start.parent;
+                }
+                start = start.parent;
+            }
+            return null;
+        }
+        return findSuc(start);
+    }
+
+    private Node findSuc(Node n) {
+        return n.left == null ? n : findSuc(n.left);
+    }
+
+    private class Node {
+        public int value;
+        public Node left;
+        public Node right;
+        public Node parent;
+
+        public Node(int value) {
+            this.value = value;
+            right = null;
+            left = null;
+        }
+
+        public Node(int value, Node left, Node right) {
+            this.value = value;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    public static void main(String[] args) {
+
+    }
+}


### PR DESCRIPTION
[Issue.](https://github.com/spiralgo/algorithms/issues/19)
We have previously encountered in [this question](https://github.com/spiralgo/algorithms/issues/15), so it might be helpful to revise that before solving this.
`is`: inorder successor

The idea is simple:
If a node has a right node, then the `is` should be the leftmost node at that side of tree. 
Else, if a node has a parent node and its left node is the node, then the `is` is the node's parent. 
Else, if a node has a parent node and its right node is the node, then the `is` is the parent's parent if its parent is its corresponding left node, if its however the right node, then we must recursively climb up the tree, until we find a node that is its parent's left node.
If all these do not work, then the result is `null`, as there is no  `is`.