### PR TITLE
1151. Minimum Swaps to Group All 1's Together

### DIFF
--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -14,7 +14,7 @@ public class MinimumSwaps {
                   return 0;
             }
             int minChanges = windowSize;
-            for(int i = 0; i<data.length-windowSize; i++)
+            for(int i = 0; i<=data.length-windowSize; i++)
             {
                   minChanges = Math.min(minChanges, countZeros(i));
             }

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -1,43 +1,27 @@
 package algorithms.curated170.medium;
 
 public class MinimumSwaps {
-      private int[] data;
-      private int windowSize = 0;
 
-      public int minimumSwaps(int[] data) {
-            this.data = data;
+      public int minSwaps(int[] data) {
+            int windowSize = 0;
+
             for (int i : data) {
-                  if (i == 1) {
-                        windowSize++;
-                  }
-            }
-            if (windowSize == 0 || windowSize == 1) {
-                  return 0;
+                  windowSize += i;
             }
 
             int minChanges = 0;
             for (int i = 0; i < windowSize; i++) {
-                  System.out.println(i + " " + data[i]);
-                  if (data[i] == 0) {
-                        minChanges++;
-                  }
+
+                  minChanges += (1 - data[i]);
+
             }
 
-            System.out.println(windowSize + " " + minChanges);
             int prev = minChanges;
-            for (int l = 1, r = windowSize; l <= data.length - windowSize; l++, r++) {
-                  int a = data[l-1], b = data[r];
-                  System.out.println("index: " + l + " prev: " + prev + " a: " + a + " b: " + b + " minChanges: " + minChanges);
-                  if (a == b) {
-                        continue;
-                  }
-                  
-                  if (a > b) {
-                        prev++;
-                  } else if (a < b) {
-                        prev--;
-                  }
-                  System.out.println(prev);
+
+            for (int i = windowSize; i < data.length; i++) {
+
+                  prev += data[i - windowSize] - data[i];
+
                   minChanges = Math.min(minChanges, prev);
             }
             return minChanges;
@@ -46,6 +30,7 @@ public class MinimumSwaps {
       public static void main(String[] args) {
 
             var solution = new MinimumSwaps();
-            System.out.println(solution.minimumSwaps(new int[] {1,0,1,0,1,0,1,1,1,0,1,0,0,1,1,1,0,0,1,1,1,0,1,0,1,1,0,0,0,1,1,1,1,0,0,1}));
+            System.out.println(solution.minimumSwaps(new int[] { 1, 0, 1, 0, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0,
+                        1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1 }));
       }
 }

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -13,18 +13,35 @@ public class MinimumSwaps {
             if (windowSize == 0 || windowSize == 1) {
                   return 0;
             }
-            int minChanges = windowSize;
-            for(int i = 0; i<=data.length-windowSize; i++)
+            int minChanges = countFirstZeros();
+            int prev = minChanges;
+            for(int i = 1; i<=data.length-windowSize; i++)
             {
-                  minChanges = Math.min(minChanges, countZeros(i));
+                  if(data[i] == 1 && data[i-1] == 0)
+                  {
+                        prev--;
+                  }
+                  else if(data[i] == 0 && data[i-1] == 1)
+                  {
+                        prev++;
+                  }
+                  if(data[i+windowSize-1] == 1 && data[i+windowSize-2] == 0)
+                  {
+                        prev--;
+                  }
+                  else if(data[i+windowSize-1] == 0 && data[i+windowSize-2] == 1)
+                  {
+                        prev++;
+                  }
+                  minChanges = Math.min(minChanges, prev);
             }
             return minChanges;
       }
 
-      private int countZeros(int index)
+      private int countFirstZeros()
       {
             int count = 0;
-            for(int i = index; i<index+windowSize; i++)
+            for(int i = 0; i<windowSize; i++)
             {
                   if(data[i] == 0)
                   {

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -3,6 +3,7 @@ package algorithms.curated170.medium;
 public class MinimumSwaps {
       private int[] data;
       private int windowSize = 0;
+
       public int minimumSwaps(int[] data) {
             this.data = data;
             for (int i : data) {
@@ -13,24 +14,24 @@ public class MinimumSwaps {
             if (windowSize == 0 || windowSize == 1) {
                   return 0;
             }
-            int minChanges = countFirstZeros();
-            int prev = minChanges;
-            for(int i = 1; i<=data.length-windowSize; i++)
-            {
-                  if(data[i] == 1 && data[i-1] == 0)
-                  {
-                        prev--;
+
+            int minChanges = 0;
+            for (int i = 0; i < windowSize; i++) {
+                  if (data[i] == 0) {
+                        minChanges++;
                   }
-                  else if(data[i] == 0 && data[i-1] == 1)
-                  {
+            }
+
+            int prev = minChanges;
+            for (int i = 1; i <= data.length - windowSize; i++) {
+                  if (data[i] == 1 && data[i - 1] == 0) {
+                        prev--;
+                  } else if (data[i] == 0 && data[i - 1] == 1) {
                         prev++;
                   }
-                  if(data[i+windowSize-1] == 1 && data[i+windowSize-2] == 0)
-                  {
+                  if (data[i + windowSize - 1] == 1 && data[i + windowSize - 2] == 0) {
                         prev--;
-                  }
-                  else if(data[i+windowSize-1] == 0 && data[i+windowSize-2] == 1)
-                  {
+                  } else if (data[i + windowSize - 1] == 0 && data[i + windowSize - 2] == 1) {
                         prev++;
                   }
                   minChanges = Math.min(minChanges, prev);
@@ -38,22 +39,9 @@ public class MinimumSwaps {
             return minChanges;
       }
 
-      private int countFirstZeros()
-      {
-            int count = 0;
-            for(int i = 0; i<windowSize; i++)
-            {
-                  if(data[i] == 0)
-                  {
-                        count++;
-                  }
-            }
-            return count;
-      }
-
       public static void main(String[] args) {
 
             var solution = new MinimumSwaps();
-            System.out.println(solution.minimumSwaps(new int[] {1,0,0,0,1,0,0,0,1,0,0,0,0,0,0,1}));
+            System.out.println(solution.minimumSwaps(new int[] { 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1 }));
       }
 }

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -25,10 +25,11 @@ public class MinimumSwaps {
             int prev = minChanges;
             for (int l = 1, r = windowSize; l <= data.length - windowSize; l++, r++) {
                   int a = data[l], b = data[r];
+                  
                   if (a == b) {
                         continue;
                   }
-                  System.out.println(a + " " + b +  " prev: " + prev + " index: " + l);
+                  
                   if (a > b) {
                         prev--;
                   } else if (a < b) {

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -1,0 +1,40 @@
+package algorithms.curated170.medium;
+
+public class MinimumSwaps {
+      private int[] data;
+      private int windowSize = 0;
+      public int minimumSwaps(int[] data) {
+            this.data = data;
+            for (int i : data) {
+                  if (i == 1) {
+                        windowSize++;
+                  }
+            }
+            if (windowSize == 0 || windowSize == 1) {
+                  return 0;
+            }
+            int minChanges = windowSize;
+            for(int i = 0; i<data.length-windowSize; i++)
+            {
+                  minChanges = Math.min(minChanges, countZeros(i));
+            }
+            return minChanges;
+      }
+
+      private int countZeros(int index)
+      {
+            int count = 0;
+            for(int i = index; i<index+windowSize; i++)
+            {
+                  if(data[i] == 0)
+                  {
+                        count++;
+                  }
+            }
+            return count;
+      }
+
+      public static void main(String[] args) {
+
+      }
+}

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -36,5 +36,7 @@ public class MinimumSwaps {
 
       public static void main(String[] args) {
 
+            var solution = new MinimumSwaps();
+            System.out.println(solution.minimumSwaps(new int[] {1,0,0,0,1,0,0,0,1,0,0,0,0,0,0,1}));
       }
 }

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -24,18 +24,18 @@ public class MinimumSwaps {
 
             int prev = minChanges;
             for (int i = 1; i <= data.length - windowSize; i++) {
-                  if(data[i] == data[i - 1] && data[i + windowSize - 1] == data[i + windowSize - 2])
-                  {
+                  int a = data[i], b = data[i - 1], c = data[i + windowSize - 1], d = data[i + windowSize - 2];
+                  if (a == b && c == d) {
                         continue;
                   }
-                  if (data[i] == 1 && data[i - 1] == 0) {
+                  if (a > b) {
                         prev--;
-                  } else if (data[i] == 0 && data[i - 1] == 1) {
+                  } else if (a < b) {
                         prev++;
                   }
-                  if (data[i + windowSize - 1] == 1 && data[i + windowSize - 2] == 0) {
+                  if (c > d) {
                         prev--;
-                  } else if (data[i + windowSize - 1] == 0 && data[i + windowSize - 2] == 1) {
+                  } else if (c < d) {
                         prev++;
                   }
                   minChanges = Math.min(minChanges, prev);

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -23,19 +23,15 @@ public class MinimumSwaps {
             }
 
             int prev = minChanges;
-            for (int i = 1; i <= data.length - windowSize; i++) {
-                  int a = data[i], b = data[i - 1], c = data[i + windowSize - 1], d = data[i + windowSize - 2];
-                  if (a == b && c == d) {
+            for (int l = 1, r = windowSize; l <= data.length - windowSize; l++, r++) {
+                  int a = data[l], b = data[r];
+                  if (a == b) {
                         continue;
                   }
+                  System.out.println(a + " " + b +  " prev: " + prev + " index: " + l);
                   if (a > b) {
                         prev--;
                   } else if (a < b) {
-                        prev++;
-                  }
-                  if (c > d) {
-                        prev--;
-                  } else if (c < d) {
                         prev++;
                   }
                   minChanges = Math.min(minChanges, prev);
@@ -46,6 +42,6 @@ public class MinimumSwaps {
       public static void main(String[] args) {
 
             var solution = new MinimumSwaps();
-            System.out.println(solution.minimumSwaps(new int[] { 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1 }));
+            System.out.println(solution.minimumSwaps(new int[] { 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1}));
       }
 }

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -24,6 +24,10 @@ public class MinimumSwaps {
 
             int prev = minChanges;
             for (int i = 1; i <= data.length - windowSize; i++) {
+                  if(data[i] == data[i - 1] && data[i + windowSize - 1] == data[i + windowSize - 2])
+                  {
+                        continue;
+                  }
                   if (data[i] == 1 && data[i - 1] == 0) {
                         prev--;
                   } else if (data[i] == 0 && data[i - 1] == 1) {

--- a/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
+++ b/src/main/java/algorithms/curated170/medium/MinimumSwaps.java
@@ -17,24 +17,27 @@ public class MinimumSwaps {
 
             int minChanges = 0;
             for (int i = 0; i < windowSize; i++) {
+                  System.out.println(i + " " + data[i]);
                   if (data[i] == 0) {
                         minChanges++;
                   }
             }
 
+            System.out.println(windowSize + " " + minChanges);
             int prev = minChanges;
             for (int l = 1, r = windowSize; l <= data.length - windowSize; l++, r++) {
-                  int a = data[l], b = data[r];
-                  
+                  int a = data[l-1], b = data[r];
+                  System.out.println("index: " + l + " prev: " + prev + " a: " + a + " b: " + b + " minChanges: " + minChanges);
                   if (a == b) {
                         continue;
                   }
                   
                   if (a > b) {
-                        prev--;
-                  } else if (a < b) {
                         prev++;
+                  } else if (a < b) {
+                        prev--;
                   }
+                  System.out.println(prev);
                   minChanges = Math.min(minChanges, prev);
             }
             return minChanges;
@@ -43,6 +46,6 @@ public class MinimumSwaps {
       public static void main(String[] args) {
 
             var solution = new MinimumSwaps();
-            System.out.println(solution.minimumSwaps(new int[] { 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 1}));
+            System.out.println(solution.minimumSwaps(new int[] {1,0,1,0,1,0,1,1,1,0,1,0,0,1,1,1,0,0,1,1,1,0,1,0,1,1,0,0,0,1,1,1,1,0,0,1}));
       }
 }


### PR DESCRIPTION
In the given array, all 1's must be grouped together. This is logically equivalent to saying that all 1's should be located in a given window in the array, length of which is the number of 1's in the array.
We count that there are 5 1's in the array. 
For example there is this window starting at some index: 1, 1, 0, 0, 1
This means that we need to swap out the 2 0's in order to have only 1's in this window, and hence all the 1's together.
With this procedure, we check all the windows in the array and return the least amount of 0's that is counted in any of these windows.