### PR TITLE
1272. Remove Interval

### DIFF
--- a/src/main/java/algorithms/curated170/medium/RemoveInterval.java
+++ b/src/main/java/algorithms/curated170/medium/RemoveInterval.java
@@ -1,0 +1,34 @@
+package algorithms.curated170.medium;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+public class RemoveInterval {
+
+    public int[][] solution(int[][] intervals, int[] toBeRemoved) {
+        List<int[]> intervals_ = new ArrayList<>();
+        int start = toBeRemoved[0], end = toBeRemoved[1];
+        for (int[] interval : intervals) {
+            
+            if (interval[1] <= start || interval[0] >= end) {
+                intervals_.add(interval);
+                continue;
+            }
+            
+            if (interval[0] < start) {
+                intervals_.add(new int[]{interval[0], start})
+            }
+            if (interval[1] > end) {
+                intervals_.add(new int[]{end, interval[1]})
+            }
+
+        }
+        return (int[][]) intervals_.toArray();
+    }
+
+    public static void main(String[] args) {
+
+    }
+}


### PR DESCRIPTION
In this question, the given list is a sorted list, the output is also required to be sorted. So it's then the past practice to save these new intervals looping through the orıiginals.
There are 3 removal cases:
(Interval input) W = [a, b]; (Interval to remove) E = [c, d]
Case 1:  b < c: This means that W ends before E starts. Then, W should be added to the list without any changes.
Case 2:  a > d: This means that W starts after E end. Then, add W in the same way.
Case 3:  a < c:  This means that this interval begins at a but must end at c, because the rest is removed.
Case 4:  b > d:  This means that this interval ends at b but must begin at d, because the interval here is removed.
Case 5: W is an interval inside E, it does not get added.

Case 3 and Case 4 can work together. Consider: W = [ 2, 7 ]; E = [ 3, 5 ]
Then, we will add two arrays [ 2, 3 ] and [ 5, 7 ] to the list.