### PR TITLE
1102. Lexicographically Smallest Equivalent String Methods Patch

### DIFF
--- a/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
+++ b/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
@@ -7,7 +7,7 @@ public class LexicographicallySmallestEquivalentString {
 
     private Map<Character, Character> parent;
 
-    String smallestEquivalentString(String A, String B, String S) {
+    public String smallestEquivalentString(String A, String B, String S) {
         parent = new HashMap<>();
 
         for (int i = 0; i < A.length(); i++) {

--- a/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
+++ b/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
@@ -17,6 +17,7 @@ public class LexicographicallySmallestEquivalentString {
         for (int i = 0; i < A.length(); i++) {
             union(A.charAt(i), B.charAt(i));
         }
+        System.out.println(parent);
         
         StringBuilder sb = new StringBuilder("");
         for (int i = 0; i < S.length(); i++) {
@@ -26,10 +27,10 @@ public class LexicographicallySmallestEquivalentString {
     }
 
     char find(char c) {
-        if (c != parent.get(c)) {
-            parent.put(c, find(parent.get(c)));
+        if (c == parent.getOrDefault(c, c)) {
+            return c;
         }
-        return parent.get(c);
+        return find(parent.get(c));
     }
 
     void union(char a, char b) {
@@ -46,9 +47,11 @@ public class LexicographicallySmallestEquivalentString {
     }
 
     public static void main(String[] args) {
-        String A = "parker", B = "morris", S = "parser";
+        
         var solution = new LexicographicallySmallestEquivalentString();
-        //System.out.println(solution.smallestEquivalentString("aefgbz", "cdgbcz", S));
+        String A = "parker", B = "morris", S = "parser";
         System.out.println(solution.smallestEquivalentString(A, B, S));
+        System.out.println(solution.smallestEquivalentString("hello", "world", "hold"));
+        System.out.println(solution.smallestEquivalentString("leetcode", "programs", "sourcecode"));
     }
 }

--- a/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
+++ b/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
@@ -3,42 +3,52 @@ package algorithms.curated170.medium;
 import java.util.HashMap;
 import java.util.Map;
 
- 
 public class LexicographicallySmallestEquivalentString {
-    private static Map<Character, Character> parent = new HashMap();
-    
-    public static void main(String[] args) {
-        String a = "parker", b = "morris";
-        String S = "parser";
-        for (int i = 0; i < a.length(); i++) {
-            parent.put(a.charAt(i), a.charAt(i));
-            parent.put(b.charAt(i), b.charAt(i));
+
+    private Map<Character, Character> parent;
+
+    String smallestEquivalentString(String A, String B, String S) {
+        parent = new HashMap<>();
+
+        for (int i = 0; i < A.length(); i++) {
+            parent.put(A.charAt(i), A.charAt(i));
+            parent.put(B.charAt(i), B.charAt(i));
         }
-        for (int i = 0; i < a.length(); i++) {
-            union(a.charAt(i), b.charAt(i));
+        for (int i = 0; i < A.length(); i++) {
+            union(A.charAt(i), B.charAt(i));
         }
-        StringBuilder sb= new StringBuilder("");
+        
+        StringBuilder sb = new StringBuilder("");
         for (int i = 0; i < S.length(); i++) {
             sb.append(find(S.charAt(i)));
         }
-        System.out.println(sb.toString());
+        return sb.toString();
     }
 
-   static char find(char c){
-        if(c == parent.get(c)){
-            return c;
+    char find(char c) {
+        if (c != parent.get(c)) {
+            parent.put(c, find(parent.get(c)));
         }
-        return find(parent.get(c));
+        return parent.get(c);
     }
-    static void union(char a, char b){
+
+    void union(char a, char b) {
         char parentA = find(a);
         char parentB = find(b);
-        if(parentA == parentB) return;
-        
-        if(parentA < parentB){
+        if (parentA == parentB)
+            return;
+
+        if (parentA < parentB) {
             parent.put(parentB, parentA);
-        }else{
+        } else {
             parent.put(parentA, parentB);
         }
+    }
+
+    public static void main(String[] args) {
+        String A = "parker", B = "morris", S = "parser";
+        var solution = new LexicographicallySmallestEquivalentString();
+        //System.out.println(solution.smallestEquivalentString("aefgbz", "cdgbcz", S));
+        System.out.println(solution.smallestEquivalentString(A, B, S));
     }
 }

--- a/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
+++ b/src/main/java/algorithms/curated170/medium/LexicographicallySmallestEquivalentString.java
@@ -17,11 +17,10 @@ public class LexicographicallySmallestEquivalentString {
         for (int i = 0; i < A.length(); i++) {
             union(A.charAt(i), B.charAt(i));
         }
-        System.out.println(parent);
         
         StringBuilder sb = new StringBuilder("");
-        for (int i = 0; i < S.length(); i++) {
-            sb.append(find(S.charAt(i)));
+        for (char s : S.toCharArray()) {
+            sb.append(find(s));
         }
         return sb.toString();
     }


### PR DESCRIPTION
[Issue.](https://github.com/spiralgo/algorithms/issues/186)
Firstly, the solution procedure was in the main method, so I created a method as wanted in the question an moved the solution there.

Additionally, in the find method we have to add a `getOrDefault( )` check. In our target String `S`, there might be letters that were not present in `A` and `B`. We do not replace these letters and let them stay as they are, because the equivalence operation is reflexive here. The reason why this is important is understandable in the example `smallestEquivalentString("leetcode", "programs", "sourcecode")`
There, the output is `"aauaaaaada"`, the 'u' is left unchanged, because we haven't encountered it in the two strings, which means that its smallest equivalent char is itself.