### PR TITLE
807. Max Increase to Keep City Skyline

### DIFF
--- a/src/main/java/algorithms/medium/MaxIncreaseToKeepCitySkyline.java
+++ b/src/main/java/algorithms/medium/MaxIncreaseToKeepCitySkyline.java
@@ -2,7 +2,7 @@ package algorithms.medium;
 
 public class MaxIncreaseToKeepCitySkyline {
 
-    public int solution(int[][] grid) {
+    public int maxIncreaseKeepingSkyline(int[][] grid) {
         int[] rowMax = new int[grid.length];
         int[] colMax = new int[grid[0].length];
         for (int i = 0; i < grid.length; i++) {

--- a/src/main/java/algorithms/medium/MaxIncreaseToKeepCitySkyline.java
+++ b/src/main/java/algorithms/medium/MaxIncreaseToKeepCitySkyline.java
@@ -1,0 +1,27 @@
+package algorithms.medium;
+
+public class MaxIncreaseToKeepCitySkyline {
+
+    public int solution(int[][] grid) {
+        int[] rowMax = new int[grid.length];
+        int[] colMax = new int[grid[0].length];
+        for (int i = 0; i < grid.length; i++) {
+            for (int j = 0; j < grid[0].length; j++) {
+                rowMax[i] = Math.max(rowMax[i], grid[i][j]);
+                colMax[j] = Math.max(colMax[j], grid[i][j]);
+            }
+        }
+        int maxIncrease = 0;
+        for (int i = 0; i < grid.length; i++) {
+            for (int j = 0; j < grid[0].length; j++) {
+                int height = grid[i][j];
+                maxIncrease += Math.min(rowMax[i], colMax[j]) - height;
+            }
+        }
+        return maxIncrease;
+    }
+
+    public static void main(String[] args) {
+
+    }
+}


### PR DESCRIPTION
[The question on LeetCode](https://leetcode.com/problems/max-increase-to-keep-city-skyline/submissions/)
This is a none-curated170 question that I have come across. When I noticed the solution idea, I wanted to document it here as well.
The question wants us to increase the numbers in the grid (i.e. the heights of the buildings), so that the skyline of the city from left-right or top-down does not change. The skyline is equivalent to the maximum height or the number in a column or a row. The fact that we need to increase the number without changing the skyline means that we have to increase the numbers without them changing the maximum value in their column and row. This means that numbers should be increased to the minimum of the maximum values of their respective columns and rows. This the intuition behind this solution.

LeetCode Submission result:
![image](https://user-images.githubusercontent.com/63192680/118389986-5e818300-b635-11eb-9a4e-6cfe31ce740e.png)
