### PR TITLE
Adds DFS, Union-Find Array, Union-Find HashMap solutions (Sentence Similarity II)

### DIFF
--- a/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIDFS.java
+++ b/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIDFS.java
@@ -1,0 +1,58 @@
+package algorithms.curated170.medium.sentencesimilarity2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class SentenceSimilarityIIDFS {
+
+    Map<String, List<String>> graph;
+    HashSet<String> visited;
+
+    public boolean areSentencesSimilarTwo(String[] words1, String[] words2, List<List<String>> pairs) {
+        if (words1.length != words2.length) {
+            return false;
+        }
+        graph = new HashMap();
+
+        for (List<String> pair : pairs) {
+            for (String p : pair) {
+                if (!graph.containsKey(p)) {
+                    graph.put(p, new ArrayList());
+                }
+            }
+            graph.get(pair.get(0)).add(pair.get(1));
+            graph.get(pair.get(1)).add(pair.get(0));
+        }
+        for (int i = 0; i < words1.length; ++i) {
+            visited = new HashSet();
+            String w1 = words1[i], w2 = words2[i];
+            if (!dfs(w1, w2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean dfs(String w1, String w2) {
+
+        visited.add(w2);
+        if (w1.equals(w2)) {
+            return true;
+        }
+
+        if (graph.containsKey(w2)) {
+            List<String> connectedWords = graph.get(w2);
+            for (String word : connectedWords) {
+                if (!visited.contains(word) && dfs(w1, word)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIDFS.java
+++ b/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIDFS.java
@@ -19,9 +19,7 @@ public class SentenceSimilarityIIDFS {
 
         for (List<String> pair : pairs) {
             for (String p : pair) {
-                if (!graph.containsKey(p)) {
-                    graph.put(p, new ArrayList());
-                }
+               graph.putIfAbsent(p, new ArrayList());
             }
             graph.get(pair.get(0)).add(pair.get(1));
             graph.get(pair.get(1)).add(pair.get(0));

--- a/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindArray.java
+++ b/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindArray.java
@@ -1,0 +1,52 @@
+package algorithms.curated170.medium.sentencesimilarity2;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SentenceSimilarityIIUnionFindArray {
+
+ public boolean areSentencesSimilarTwo(String[] words1, String[] words2, List<List<String>> pairs) {
+        if (words1.length != words2.length) {
+            return false;
+        }
+ 
+        Map<String, Integer> index = new HashMap();
+        int count = 0;
+        DSU dsu = new DSU(2 * pairs.size());
+        
+        for (List<String> pair : pairs) {
+            for (String p: pair){
+              if (!index.containsKey(p)) {
+                index.put(p, count++);
+            }  
+            } 
+            dsu.union(index.get(pair.get(0)), index.get(pair.get(1)));
+        }
+
+        for (int i = 0; i < words1.length; ++i) {
+            String w1 = words1[i], w2 = words2[i];
+            if (w1.equals(w2)) continue;
+            if (!index.containsKey(w1) || !index.containsKey(w2) ||
+                    dsu.find(index.get(w1)) != dsu.find(index.get(w2)))
+                return false;
+        }
+        return true;
+    }
+}
+
+class DSU {
+    int[] parent;
+    public DSU(int N) {
+        parent = new int[N];
+        for (int i = 0; i < N; ++i)
+            parent[i] = i;
+    }
+    public int find(int x) {
+        if (parent[x] != x) parent[x] = find(parent[x]);
+        return parent[x];
+    }
+    public void union(int x, int y) {
+        parent[find(x)] = find(y);
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindArray.java
+++ b/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindArray.java
@@ -5,8 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 public class SentenceSimilarityIIUnionFindArray {
-
- public boolean areSentencesSimilarTwo(String[] words1, String[] words2, List<List<String>> pairs) {
+  public boolean areSentencesSimilarTwo(String[] words1, String[] words2, List<List<String>> pairs) {
         if (words1.length != words2.length) {
             return false;
         }
@@ -17,10 +16,8 @@ public class SentenceSimilarityIIUnionFindArray {
         
         for (List<String> pair : pairs) {
             for (String p: pair){
-              if (!index.containsKey(p)) {
-                index.put(p, count++);
-            }  
-            } 
+              index.putIfAbsent(p, count++);
+           } 
             dsu.union(index.get(pair.get(0)), index.get(pair.get(1)));
         }
 
@@ -33,20 +30,21 @@ public class SentenceSimilarityIIUnionFindArray {
         }
         return true;
     }
+    class DSU {
+        int[] parent;
+        public DSU(int N) {
+            parent = new int[N];
+            for (int i = 0; i < N; ++i)
+                parent[i] = i;
+        }
+        public int find(int x) {
+            if (parent[x] != x) parent[x] = find(parent[x]);
+            return parent[x];
+        }
+        public void union(int x, int y) {
+            parent[find(x)] = find(y);
+        }
+    }
 }
 
-class DSU {
-    int[] parent;
-    public DSU(int N) {
-        parent = new int[N];
-        for (int i = 0; i < N; ++i)
-            parent[i] = i;
-    }
-    public int find(int x) {
-        if (parent[x] != x) parent[x] = find(parent[x]);
-        return parent[x];
-    }
-    public void union(int x, int y) {
-        parent[find(x)] = find(y);
-    }
-}
+

--- a/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindMap.java
+++ b/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindMap.java
@@ -1,0 +1,56 @@
+package algorithms.curated170.medium.sentencesimilarity2;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+ 
+public class SentenceSimilarityIIUnionFindMap {
+  Map<String, String> parent = new HashMap();
+
+    public boolean areSentencesSimilarTwo(String[] words1, String[] words2, List<List<String>> pairs) {
+        if (words1.length != words2.length) {
+            return false;
+        }
+
+        for (List<String> pair : pairs) {
+
+            for (String p : pair) {
+                parent.put(p, p);
+            }
+        }
+        for (List<String> pair : pairs) {
+
+            union(pair.get(0), pair.get(1));
+        }
+        for (int i = 0; i < words1.length; ++i) {
+
+            String w1 = words1[i], w2 = words2[i];
+            String parentWord1 = find(w1);
+            String parentWord2 = find(w2);
+            if (!parentWord1.equals(parentWord2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    String find(String w1) {
+        if(!parent.containsKey(w1)) return w1;
+        String parentWord = parent.get(w1);
+        if (parentWord.equals(w1)) {
+            return w1;
+        }
+        return find(parentWord);
+    }
+
+    void union(String w1, String w2) {
+        String parentWord1 = find(w1);
+        String parentWord2 = find(w2);
+ 
+        if (!parentWord1.equals(parentWord2)) {
+            parent.put(find(w1), find(w2));
+        }
+    }
+
+}

--- a/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindMap.java
+++ b/src/main/java/algorithms/curated170/medium/sentencesimilarity2/SentenceSimilarityIIUnionFindMap.java
@@ -23,6 +23,7 @@ public class SentenceSimilarityIIUnionFindMap {
 
             union(pair.get(0), pair.get(1));
         }
+        
         for (int i = 0; i < words1.length; ++i) {
 
             String w1 = words1[i], w2 = words2[i];
@@ -35,22 +36,24 @@ public class SentenceSimilarityIIUnionFindMap {
         return true;
     }
 
-    String find(String w1) {
+  String find(String w1) {
         if(!parent.containsKey(w1)) return w1;
         String parentWord = parent.get(w1);
-        if (parentWord.equals(w1)) {
-            return w1;
+        if (!parentWord.equals(w1)) {
+            parent.put(w1, find(parentWord));
         }
-        return find(parentWord);
+        return parent.get(w1);
     }
 
     void union(String w1, String w2) {
+   
         String parentWord1 = find(w1);
         String parentWord2 = find(w2);
  
         if (!parentWord1.equals(parentWord2)) {
-            parent.put(find(w1), find(w2));
+            parent.put(parentWord1, parentWord2);
         }
     }
+
 
 }


### PR DESCRIPTION
Resolves: https://github.com/spiralgo/algorithms/issues/66

When we represent the connections of the word pairs as a `graph`, it becomes easier to solve the problem using either DFS or Union-Find.

In the algorithm, we will mainly ask two questions to decide if the given sentences are similar:
1- Do the sentences have the same number of words?
2- Are the words (at the same index of the given sentences) similar?
    - If we use `DFS`, this means "Does the pair graph have a cycle for these two words?"
    - If we use `Union-Find`, this means "Are these two words in the same group with the same parent?"
    
    

> For example, sentence1= ["great", "acting", "skills"] and sentence2= ["fine", "drama", "talent"] are similar, if the similar word pairs are similar = [["great", "good"], ["fine", "good"], ["acting","drama"], ["skills","talent"]].

    
 
![IMG-1635](https://user-images.githubusercontent.com/60903744/120077522-6fa9a580-c0b3-11eb-9bbe-94b7b96708c7.jpg)


