### PR TITLE
Adds Array and PQ solutions (253. Meeting Rooms II)

### DIFF
--- a/src/main/java/algorithms/curated170/medium/meetingrooms2/MeetingRoomsIIArray.java
+++ b/src/main/java/algorithms/curated170/medium/meetingrooms2/MeetingRoomsIIArray.java
@@ -1,0 +1,33 @@
+package algorithms.curated170.medium.meetingrooms2;
+
+import java.util.Arrays; 
+
+ 
+public class MeetingRoomsIIArray {
+     public int minMeetingRooms(int[][] intervals) {
+        int[] startTimes = new int[intervals.length];
+        int[] endTimes = new int[intervals.length];
+        
+        for (int i = 0; i < intervals.length; i++) {
+            startTimes[i] = intervals[i][0];
+            endTimes[i] = intervals[i][1];
+        }
+        
+        Arrays.sort(startTimes);
+        Arrays.sort(endTimes);
+        
+        int requiredRooms = 1;
+        int i = 1;
+        int j = 0;
+        
+        while (i < intervals.length) {
+            if (startTimes[i++] < endTimes[j]) {
+                requiredRooms++;
+            } else{
+                 j++; 
+            } 
+               
+        }
+        return requiredRooms;
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/meetingrooms2/MeetingRoomsIIPQ.java
+++ b/src/main/java/algorithms/curated170/medium/meetingrooms2/MeetingRoomsIIPQ.java
@@ -1,0 +1,28 @@
+package algorithms.curated170.medium.meetingrooms2;
+
+import java.util.Arrays;
+import java.util.PriorityQueue;
+
+public class MeetingRoomsIIPQ {
+
+    public int minMeetingRooms(int[][] intervals) {
+        PriorityQueue<Integer> endTimes = new PriorityQueue();
+        int requiredRooms = 1;
+        Arrays.sort(intervals, (a, b) -> Integer.compare(a[0], b[0]));
+
+        for (int i = 0; i < intervals.length - 1; i++) {
+            endTimes.add(intervals[i][1]);
+        }
+
+        for (int i = 0; i < intervals.length - 1; i++) {
+            int currentMinimumEnd = endTimes.poll();
+
+            if (currentMinimumEnd > intervals[i + 1][0]) {
+                requiredRooms++;
+                endTimes.add(currentMinimumEnd);
+            }
+        }
+
+        return requiredRooms;
+    }
+}


### PR DESCRIPTION
Resolves: https://github.com/spiralgo/algorithms/issues/64

I think the simplest intuition to solve this question might be like that:

 - If there is just 1 meeting, we would need just 1 room.
 - Even if there is more than 1 meeting; if the next meetings start just after the end of the previous ones, then again we would need just 1 room. 
 - If this is not the case, we can try to use the same room for one or more meetings.

  `Conclusion`: We can use a vacated room `for any meeting` that is supposed to be held after `the meeting which ended first` (namely, the interval which has the minimum end.)
  
  It is why we need to keep track of already ended meetings and somehow poll the minimum one.
  
  PQ is a perfect match for that purpose. However, if the same idea is implemented using an array, it will be more efficient.
  
  Therefore, I add both implementations.
  
For the example below, we would need one room for [0,30] and an extra room for the others. 
We would need 2 rooms at the end.

![IMG-1630](https://user-images.githubusercontent.com/60903744/119862835-9b952180-bf21-11eb-93b8-bad64c1fdbb2.jpg)
