### PR TITLE
325. Maximum Size Subarray Sum Equals k 

### DIFF
--- a/src/main/java/algorithms/curated170/medium/MaximumSizeSubarrayEqualsK.java
+++ b/src/main/java/algorithms/curated170/medium/MaximumSizeSubarrayEqualsK.java
@@ -1,25 +1,40 @@
 package algorithms.curated170.medium;
 
-import java.util.HashMap;
+import java.util.HashMap;    
+
 
 public class MaximumSizeSubarrayEqualsK {
+
       public int maxSubArrayLen(int[] nums, int k) {
-            HashMap<Integer, Integer> indexStart = new HashMap<>();
-            int tempSum = 0;
+
+            HashMap<Integer, Integer> sumIndices = new HashMap<>(){{
+                  put(0, -1);
+            }};
+            int currSum = 0;
             int maxRange = 0;
             for (int i = 0; i < nums.length; i++) {
-                  int num = nums[i];
-                  tempSum += num;
-                  maxRange = Math.max(maxRange, i - indexStart.getOrDefault(tempSum - 3, Integer.MAX_VALUE));
-                  System.out.println(indexStart);
-                  if(!indexStart.containsKey(tempSum)) indexStart.put(tempSum, i);
+                  currSum += nums[i];
+
+                  maxRange = Math.max(maxRange, i - sumIndices.getOrDefault(currSum - k, Integer.MAX_VALUE));
+
+                  sumIndices.putIfAbsent(currSum, i);
             }
             return maxRange;
       }
 
       public static void main(String[] args) {
             var solution = new MaximumSizeSubarrayEqualsK();
-            int[] nums = new int[] { 1, -1, 5, -2, 3};
-            System.out.println(solution.maxSubArrayLen(nums, 3));
+
+            int[] nums = new int[] { 1, -1, 5, -2, 3, -2 };
+            System.out.println(solution.maxSubArrayLen(nums, 3)); // prints 5
+
+            nums = new int[] { 1, -1, 5, -2, 3 };
+            System.out.println(solution.maxSubArrayLen(nums, 3)); // prints 4
+
+            nums = new int[] { 3 };
+            System.out.println(solution.maxSubArrayLen(nums, 3)); // prints 1
+
+            nums = new int[] { -2, -1, 2, 1, -2 };
+            System.out.println(solution.maxSubArrayLen(nums, 1)); // prints 3
       }
 }

--- a/src/main/java/algorithms/curated170/medium/MaximumSizeSubarrayEqualsK.java
+++ b/src/main/java/algorithms/curated170/medium/MaximumSizeSubarrayEqualsK.java
@@ -1,0 +1,25 @@
+package algorithms.curated170.medium;
+
+import java.util.HashMap;
+
+public class MaximumSizeSubarrayEqualsK {
+      public int maxSubArrayLen(int[] nums, int k) {
+            HashMap<Integer, Integer> indexStart = new HashMap<>();
+            int tempSum = 0;
+            int maxRange = 0;
+            for (int i = 0; i < nums.length; i++) {
+                  int num = nums[i];
+                  tempSum += num;
+                  maxRange = Math.max(maxRange, i - indexStart.getOrDefault(tempSum - 3, Integer.MAX_VALUE));
+                  System.out.println(indexStart);
+                  if(!indexStart.containsKey(tempSum)) indexStart.put(tempSum, i);
+            }
+            return maxRange;
+      }
+
+      public static void main(String[] args) {
+            var solution = new MaximumSizeSubarrayEqualsK();
+            int[] nums = new int[] { 1, -1, 5, -2, 3};
+            System.out.println(solution.maxSubArrayLen(nums, 3));
+      }
+}


### PR DESCRIPTION
Resolves: #61 

A maximum Size subarray sum that equals `k` is an equivalent expression to this:
The sum of all numbers up to a certain index `i` equals to some sum `s`.
If we subtract k from s, and the result was previously encountered at some index `j`, that means that we have a subarray of length `i-j` that equals to `k`.
We can illustrate this with an example:
Consider the array `[7, 1, -2, 5, -1, 3]` and the value `k = 3`. The current sum at index `i = 4` is `(7+1+(-2)+5+(-1)) = 10`. When subtract `k` from this current sum, we get 7. We have previously encountered 7 at the index `j = 0`. So, `i-j = 4` will yield us a range of 4. We can calculate ranges as such and compare them to each other easily with a maximum operator and a store them in a Map.
