### PR TITLE
Adds Union-find solution with PQ  (1101. The Earliest Moment When Everyone Become Friends)

### DIFF
--- a/src/main/java/algorithms/curated170/medium/TheEarliestMomentWhenEveryoneBecomeFriends.java
+++ b/src/main/java/algorithms/curated170/medium/TheEarliestMomentWhenEveryoneBecomeFriends.java
@@ -49,7 +49,9 @@ public class TheEarliestMomentWhenEveryoneBecomeFriends {
 
         int findParent(int id) {
             while (parent[id] != id) {
-                id = parent[id];
+                int prevParent = parent[id];
+                parent[id] = parent[prevParent];
+                id = prevParent;
             }
             return id;
         }

--- a/src/main/java/algorithms/curated170/medium/TheEarliestMomentWhenEveryoneBecomeFriends.java
+++ b/src/main/java/algorithms/curated170/medium/TheEarliestMomentWhenEveryoneBecomeFriends.java
@@ -1,0 +1,70 @@
+package algorithms.curated170.medium;
+
+import java.util.PriorityQueue;
+
+public class TheEarliestMomentWhenEveryoneBecomeFriends {
+
+    class Solution {
+
+        int[] parent;
+        int[] child;
+
+        public int earliestAcq(int[][] logs, int n) {
+            parent = new int[n];
+            child = new int[n];
+
+            int id_A, id_B, parent_A, parent_B;
+
+            for (int i = 0; i < n; i++) {
+                parent[i] = i;
+                child[i] = 1;
+            }
+
+            PriorityQueue<Log> pq = new PriorityQueue<>((a, b) -> a.timestamp - b.timestamp);
+            for (int i = 0; i < logs.length; i++) {
+                pq.add(new Log(logs[i][0], logs[i][1], logs[i][2]));
+            }
+
+            Log log;
+
+            while (!pq.isEmpty()) {
+                log = pq.poll();
+                id_A = log.id_A;
+                id_B = log.id_B;
+                parent_A = findParent(id_A);
+                parent_B = findParent(id_B);
+                if (parent_A == parent_B) {
+                    continue;
+                } else {
+                    parent[parent_A] = parent_B;
+                    child[parent_B] += child[parent_A];
+                    if (child[parent_B] == n) {
+                        return log.timestamp;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        int findParent(int id) {
+            while (parent[id] != id) {
+                id = parent[id];
+            }
+            return id;
+        }
+
+        class Log {
+
+            int timestamp;
+            int id_A;
+            int id_B;
+
+            Log(int timestamp, int id_A, int id_B) {
+                this.timestamp = timestamp;
+                this.id_A = id_A;
+                this.id_B = id_B;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves:
https://github.com/spiralgo/algorithms/issues/185

Question asks:
"**Return the earliest time for which every person became acquainted with every other person.**"

It is a textbook Union-Find question.

Therefore we can **paraphrase** the question in terms of Union-Find like this:
"`Return the earliest time for which all ids (of people) became member of the same (union, one) group.`"

We can also **rephrase** above Union-find statement like this:
"`Return the earliest time for which all ids (of people) became children of the same parent.`"

 Logs are not sorted by date.
 We can use either **PQ** or **Arrays.sort**. 
 Both have almost the same efficiency.
 
 We need to create a Log class to represent any log object, similar to what we have done in https://github.com/spiralgo/algorithms/pull/286 for Point.