### PR TITLE
Read4

### DIFF
--- a/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
+++ b/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
@@ -22,6 +22,21 @@ public class ReadNCharactersGivenRead4 extends Reader4 {
      
         return copiedChars;
     }
+    
+    public int read2(char[] buf, int n) {
+        int copiedChars = 0;
+     
+        while(copiedChars < n){
+            int length = read4(buf4);
+            for(int i=0; i<length && copiedChars < n; i++){
+                buf[copiedChars++] = buf4[i];
+            }
+          
+            if(length < 4) break;
+        }
+
+        return copiedChars;
+    }
     public static void main(String[] args) {
         ReadNCharactersGivenRead4 readNCharactersGivenRead4 = new ReadNCharactersGivenRead4();
         char[] buf = new char[19];

--- a/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
+++ b/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
@@ -1,36 +1,33 @@
 package algorithms.curated170.easy;
-class Reader4{
-      int read4(char[] buf){
-          
-          //TODO
-          return -1;
-      }
-} 
+
 public class ReadNCharactersGivenRead4 extends Reader4 {
-    /**
-     * @param buf Destination buffer
-     * @param n   Number of characters to read
-     * @return    The number of actual characters read
-     */
-public int read(char[] buf, int n) {
-  boolean eof = false;      // end of file flag
-  int total = 0;            // total bytes have read
-  char[] tmp = new char[4]; // temp buffer
-  
-  while (!eof && total < n) {
-    int count = read4(tmp);
-    
-    // check if it's the end of the file
-    eof = count < 4;
-    
-    // get the actual count
-    count = Math.min(count, n - total);
-    
-    // copy from temp buffer to buf
-    for (int i = 0; i < count; i++) 
-      buf[total++] = tmp[i];
-  }
-  
-  return total;
-}
+    public int read(char[] buf, int n) { 
+        int index = 0;
+        int length = 0;
+        char[] buf4 = new char[4];
+        int copiedChars = 0;  
+
+       
+        while (copiedChars < n) {
+       
+            if (index == length) {
+                length = read4(buf4);
+                index = 0;
+                if (length == 0) {
+                    break;
+                }
+            }
+            
+            buf[copiedChars++] = buf4[index++];
+        }
+     
+        return copiedChars;
+    }
+    public static void main(String[] args) {
+        ReadNCharactersGivenRead4 readNCharactersGivenRead4 = new ReadNCharactersGivenRead4();
+        char[] buf = new char[19];
+        int total = readNCharactersGivenRead4.read(buf, 18);
+        System.out.println(total);
+     
+    }
 }

--- a/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
+++ b/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
@@ -6,7 +6,6 @@ public class ReadNCharactersGivenRead4 extends Reader4 {
         int length = 0;
         char[] buf4 = new char[4];
         int copiedChars = 0;  
-
        
         while (copiedChars < n) {
        

--- a/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
+++ b/src/main/java/algorithms/curated170/easy/ReadNCharactersGivenRead4.java
@@ -1,10 +1,11 @@
 package algorithms.curated170.easy;
 
 public class ReadNCharactersGivenRead4 extends Reader4 {
-    public int read(char[] buf, int n) { 
         int index = 0;
         int length = 0;
         char[] buf4 = new char[4];
+    public int read(char[] buf, int n) { 
+    
         int copiedChars = 0;  
        
         while (copiedChars < n) {

--- a/src/main/java/algorithms/curated170/easy/Reader4.java
+++ b/src/main/java/algorithms/curated170/easy/Reader4.java
@@ -6,9 +6,6 @@ public class Reader4 {
  
     public static int start = 0;
     public int read4(char[] buf) {
-
-     
-
         char[] tmp = fileData.substring(start, start+3).toCharArray();
         int total = 0;
         for (char c : tmp) {

--- a/src/main/java/algorithms/curated170/easy/Reader4.java
+++ b/src/main/java/algorithms/curated170/easy/Reader4.java
@@ -1,0 +1,21 @@
+package algorithms.curated170.easy;
+
+public class Reader4 {
+
+    String fileData = "TheSpiralWillExpand";
+ 
+    public static int start = 0;
+    public int read4(char[] buf) {
+
+     
+
+        char[] tmp = fileData.substring(start, start+3).toCharArray();
+        int total = 0;
+        for (char c : tmp) {
+            buf[total++] = c;
+        }
+    
+        return buf.length;
+    }
+  
+}

--- a/src/main/java/algorithms/curated170/hard/ReadNCharactersGivenRead4II.java
+++ b/src/main/java/algorithms/curated170/hard/ReadNCharactersGivenRead4II.java
@@ -1,0 +1,50 @@
+package algorithms.curated170.hard;
+
+import algorithms.curated170.easy.Reader4;
+import java.util.Arrays;
+
+public class ReadNCharactersGivenRead4II extends Reader4 {
+    int index = 0;
+    int length = 0;
+    char[] buf4 = new char[4];
+    public int read(char[] buf, int n) { 
+       
+       int copiedChars = 0;  
+
+       
+        while (copiedChars < n) {
+       
+            if (index == length) {
+                length = read4(buf4);
+                index = 0;
+                if (length == 0) {
+                    break;
+                }
+            }
+            
+            buf[copiedChars++] = buf4[index++];
+        }
+    
+        return copiedChars;
+    }
+ 
+    public static void main(String[] args) {
+        ReadNCharactersGivenRead4II readNCharactersGivenRead4II = new ReadNCharactersGivenRead4II();
+        char[] buf = new char[19];
+        int start = 0;
+        start =  readNCharactersGivenRead4II.read(buf, 3);
+        System.out.println(Arrays.toString(buf)); 
+      
+        readNCharactersGivenRead4II.index++;
+        Reader4.start += start;
+        start = readNCharactersGivenRead4II.read(buf, 3);
+        System.out.println(Arrays.toString(buf)); 
+        
+        readNCharactersGivenRead4II.index++;
+        Reader4.start += start;
+        start = readNCharactersGivenRead4II.read(buf, 3);
+        System.out.println(Arrays.toString(buf)); 
+       
+    }
+
+}

--- a/src/main/java/algorithms/curated170/hard/ReadNCharactersGivenRead4II.java
+++ b/src/main/java/algorithms/curated170/hard/ReadNCharactersGivenRead4II.java
@@ -10,9 +10,7 @@ public class ReadNCharactersGivenRead4II extends Reader4 {
     public int read(char[] buf, int n) { 
        
        int copiedChars = 0;  
-
-       
-        while (copiedChars < n) {
+       while (copiedChars < n) {
        
             if (index == length) {
                 length = read4(buf4);


### PR DESCRIPTION
Updates: https://github.com/spiralgo/algorithms/issues/161, resolves: https://github.com/spiralgo/algorithms/issues/237


The only difference between the easier one and the harder one:

The harder one (https://github.com/spiralgo/algorithms/issues/237) needs to keep the states of `index`, `buf`, `length`.

Therefore we had to define them as global variables. 

But in the easier one (https://github.com/spiralgo/algorithms/issues/161), we can use them as local variables.

 Suppose, we have a file on a remote server. The content of the file might be "**TheSpiralWillExpand**"
 As we do not have direct access to the file, we need to use the Read4 interface to read the content.
 
![IMG-1644](https://user-images.githubusercontent.com/60903744/120401902-9f71db00-c349-11eb-86a9-ff9cb10f927d.jpg)
