### PR TITLE
Adds Backtracking solution: 47. Permutations II, moves Permutations to the right package.

### DIFF
--- a/src/main/java/algorithms/medium/Permutations.java
+++ b/src/main/java/algorithms/medium/Permutations.java
@@ -1,4 +1,4 @@
-package algorithms.curated170.easy;
+package algorithms.medium;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/algorithms/medium/Permutations2.java
+++ b/src/main/java/algorithms/medium/Permutations2.java
@@ -23,11 +23,12 @@ public class Permutations2 {
             output.add(permutation);
         }
 
-        Set<Integer> visited = new HashSet<>();
+        boolean[] visited = new boolean[21];
         for (int i = choiceIndex; i < nums.length; i++) {
-            if (!visited.add(nums[i])) {
+            if (visited[nums[i] + 10]) {
                 continue;
             }
+            visited[nums[i] + 10] = true;
             swap(choiceIndex, i, nums);
             backtrack(choiceIndex + 1, nums, output);
             swap(i, choiceIndex, nums);

--- a/src/main/java/algorithms/medium/Permutations2.java
+++ b/src/main/java/algorithms/medium/Permutations2.java
@@ -1,0 +1,44 @@
+package algorithms.medium;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Permutations2 {
+
+    public List<List<Integer>> permuteUnique(int[] nums) {
+        List<List<Integer>> output = new ArrayList<List<Integer>>();
+        backtrack(0, nums, output);
+        return output;
+
+    }
+    
+    public void backtrack(int choiceIndex, int[] nums, List<List<Integer>> output) {
+        if (choiceIndex == nums.length) {
+            ArrayList<Integer> permutation = new ArrayList<Integer>();
+            for (int num : nums) {
+                permutation.add(num);
+            }
+            output.add(permutation);
+        }
+
+        Set<Integer> visited = new HashSet<>();
+        for (int i = choiceIndex; i < nums.length; i++) {
+            if (!visited.add(nums[i])) {
+                continue;
+            }
+            swap(choiceIndex, i, nums);
+            backtrack(choiceIndex + 1, nums, output);
+            swap(i, choiceIndex, nums);
+
+        }
+
+    }
+
+    public void swap(int choiceIndex, int i, int[] nums) {
+        int temp = nums[choiceIndex];
+        nums[choiceIndex] = nums[i];
+        nums[i] = temp;
+    }
+}


### PR DESCRIPTION
 Resolves: https://github.com/spiralgo/algorithms/issues/307
 
 It is almost the same with: https://github.com/spiralgo/algorithms/pull/304
 
 This time, we add a "set" named `visited` to provide unique permutations, just because `nums` may include duplicate records this time.