### PR TITLE
Adds Backtracking solution: 267. Palindrome Permutation II

### DIFF
--- a/src/main/java/algorithms/curated170/medium/PalindromePermutation2.java
+++ b/src/main/java/algorithms/curated170/medium/PalindromePermutation2.java
@@ -27,7 +27,26 @@ public class PalindromePermutation2 {
         return output;
     }
 
-    public boolean canPermutePalindrome(String halfString, int[] map) {
+    
+    void permute(char[] halfString, int choiceIndex, char ch, List<String> output) {
+        if (choiceIndex == halfString.length) {
+            output.add(addReverseToItself(new String(halfString), ch));
+        } else {
+            boolean[] visited = new boolean[128];
+
+            for (int i = choiceIndex; i < halfString.length; i++) {
+                if (visited[halfString[i]]) {
+                    continue;
+                }
+                visited[halfString[i]] = true;
+                swap(halfString, choiceIndex, i);
+                permute(halfString, choiceIndex + 1, ch, output);
+                swap(halfString, choiceIndex, i);
+
+            }
+        }
+    }
+       public boolean canPermutePalindrome(String halfString, int[] map) {
 
         for (int i = 0; i < halfString.length(); i++) {
             map[halfString.charAt(i)]++;
@@ -46,25 +65,6 @@ public class PalindromePermutation2 {
 
     }
 
-    void permute(char[] halfString, int leftPointer, char ch, List<String> output) {
-        if (leftPointer == halfString.length) {
-            output.add(addReverseToItself(new String(halfString), ch));
-        } else {
-            boolean[] visited = new boolean[128];
-
-            for (int i = leftPointer; i < halfString.length; i++) {
-                if (visited[halfString[i]]) {
-                    continue;
-                }
-                visited[halfString[i]] = true;
-                swap(halfString, leftPointer, i);
-                permute(halfString, leftPointer + 1, ch, output);
-                swap(halfString, leftPointer, i);
-
-            }
-        }
-    }
-
     String addReverseToItself(String permutedHalfString, char ch) {
         StringBuilder sb = new StringBuilder(permutedHalfString).reverse()
                 .append(ch == 0 ? "" : ch)
@@ -73,9 +73,9 @@ public class PalindromePermutation2 {
         return sb.toString();
     }
 
-    public void swap(char[] s, int leftPointer, int i) {
-        char temp = s[leftPointer];
-        s[leftPointer] = s[i];
+    public void swap(char[] s, int choiceIndex, int i) {
+        char temp = s[choiceIndex];
+        s[choiceIndex] = s[i];
         s[i] = temp;
     }
 }

--- a/src/main/java/algorithms/curated170/medium/PalindromePermutation2.java
+++ b/src/main/java/algorithms/curated170/medium/PalindromePermutation2.java
@@ -1,0 +1,81 @@
+package algorithms.curated170.medium;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PalindromePermutation2 {
+
+    public List<String> generatePalindromes(String s) {
+        int[] map = new int[128];
+        char[] halfString = new char[s.length() / 2];
+        char ch = 0;
+        if (!canPermutePalindrome(s, map)) {
+            return new ArrayList<>();
+        }
+
+        int k = 0;
+        for (int i = 0; i < map.length; i++) {
+            if (map[i] % 2 == 1) {
+                ch = (char) i;
+            }
+            for (int j = 0; j < map[i] / 2; j++) {
+                halfString[k++] = (char) i;
+            }
+        }
+        List<String> output = new ArrayList<>();
+        permute(halfString, 0, ch, output);
+        return output;
+    }
+
+    public boolean canPermutePalindrome(String halfString, int[] map) {
+
+        for (int i = 0; i < halfString.length(); i++) {
+            map[halfString.charAt(i)]++;
+        }
+
+        boolean sawSingle = false;
+        for (int key = 0; key < map.length; key++) {
+            if (map[key] % 2 == 1) {
+                if (sawSingle) {
+                    return false;
+                }
+                sawSingle = true;
+            }
+        }
+        return true;
+
+    }
+
+    void permute(char[] halfString, int leftPointer, char ch, List<String> output) {
+        if (leftPointer == halfString.length) {
+            output.add(addReverseToItself(new String(halfString), ch));
+        } else {
+            boolean[] visited = new boolean[128];
+
+            for (int i = leftPointer; i < halfString.length; i++) {
+                if (visited[halfString[i]]) {
+                    continue;
+                }
+                visited[halfString[i]] = true;
+                swap(halfString, leftPointer, i);
+                permute(halfString, leftPointer + 1, ch, output);
+                swap(halfString, leftPointer, i);
+
+            }
+        }
+    }
+
+    String addReverseToItself(String permutedHalfString, char ch) {
+        StringBuilder sb = new StringBuilder(permutedHalfString).reverse()
+                .append(ch == 0 ? "" : ch)
+                .append(permutedHalfString);
+
+        return sb.toString();
+    }
+
+    public void swap(char[] s, int leftPointer, int i) {
+        char temp = s[leftPointer];
+        s[leftPointer] = s[i];
+        s[i] = temp;
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/palindromepermutation/PalindromePermutation2.java
+++ b/src/main/java/algorithms/curated170/medium/palindromepermutation/PalindromePermutation2.java
@@ -1,12 +1,13 @@
-package algorithms.curated170.medium;
+package algorithms.curated170.medium.palindromepermutation;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PalindromePermutation2 {
 
+    final int NUM_OF_CHARS = 128;
     public List<String> generatePalindromes(String s) {
-        int[] map = new int[128];
+        int[] map = new int[NUM_OF_CHARS];
         char[] halfString = new char[s.length() / 2];
         char ch = 0;
         if (!canPermutePalindrome(s, map)) {
@@ -32,7 +33,7 @@ public class PalindromePermutation2 {
         if (choiceIndex == halfString.length) {
             output.add(addReverseToItself(new String(halfString), ch));
         } else {
-            boolean[] visited = new boolean[128];
+            boolean[] visited = new boolean[NUM_OF_CHARS];
 
             for (int i = choiceIndex; i < halfString.length; i++) {
                 if (visited[halfString[i]]) {

--- a/src/main/java/algorithms/curated170/medium/palindromepermutation/PalindromePermutationMirrored.java
+++ b/src/main/java/algorithms/curated170/medium/palindromepermutation/PalindromePermutationMirrored.java
@@ -1,0 +1,94 @@
+package algorithms.curated170.medium.palindromepermutation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PalindromePermutationMirrored {
+
+    final int NUM_OF_CHARS = 128;
+    final int ALPHABET_START = 97;
+    final int ALPHABET_END = 122;
+
+    char[] stringData;
+    int length;
+    List<String> palindromes;
+
+    public List<String> generatePalindromes(String s) {
+        int[] map = new int[NUM_OF_CHARS];
+        length = s.length();
+        stringData = new char[length];
+        palindromes = new ArrayList<>();
+
+        if (!canPermutePalindrome(s, map)) {
+            return new ArrayList<>();
+        }
+
+        createInitialString(map);
+
+        permute(0);
+        return palindromes;
+    }
+
+    private void createInitialString(int[] map) {
+        int left = 0;
+        int right = length - 1;
+        for (char i = ALPHABET_START; i <= ALPHABET_END; i++) {
+            if (map[i] == 1) {
+                continue;
+            }
+            for (int j = 0; j < map[i]; j += 2) {
+                stringData[left++] = i;
+                stringData[right--] = i;
+            }
+        }
+    }
+
+    private void permute(int choiceIndex) {
+        if (choiceIndex == length / 2) {
+            palindromes.add(new String(stringData));
+        } else {
+            boolean[] visited = new boolean[NUM_OF_CHARS];
+
+            for (int i = choiceIndex; i < stringData.length / 2; i++) {
+
+                if (visited[stringData[i]]) {
+                    continue;
+                }
+                visited[stringData[i]] = true;
+
+                swap(choiceIndex, i);
+                permute(choiceIndex + 1);
+                swap(choiceIndex, i);
+            }
+        }
+    }
+
+    private boolean canPermutePalindrome(String s, int[] map) {
+
+        for (int i = 0; i < s.length(); i++) {
+            map[s.charAt(i)]++;
+        }
+
+        boolean sawSingle = false;
+        for (char key = ALPHABET_START; key <= ALPHABET_END; key++) {
+            if (map[key] % 2 == 1) {
+                if (sawSingle) {
+                    return false;
+                }
+                stringData[length / 2] = key;
+                sawSingle = true;
+            }
+        }
+        return true;
+    }
+
+    private void swap(int choiceIndex, int i) {
+        char swapped1 = stringData[choiceIndex];
+        char swapped2 = stringData[i];
+
+        stringData[choiceIndex] = swapped2;
+        stringData[i] = swapped1;
+        stringData[length - 1 - choiceIndex] = swapped2;
+        stringData[length - 1 - i] = swapped1;
+    }
+}


### PR DESCRIPTION
Resolves:
https://github.com/spiralgo/algorithms/issues/309

(It would be great if the future audience has a look at this PR first, in view of the fact that we use almost the same backtracking method to generate permutations: https://github.com/spiralgo/algorithms/pull/308)

1- If there is no possible palindrome permutation of the string, we should not create a backtracking tree.
    
   Therefore, we can determine if a `palindrome permutation` is possible, using one of our previous codes here:  https://github.com/spiralgo/algorithms/pull/251
    
   We can create a method called `canPermutePalindrome()` to accomplish this.
   
    
2- If a palindrome is possible, we can use only half of the string's characters as palindrome can be generated by simply reversing this half and concatenate it to the reversed version.
  
   We can create a method called `addReverseToItself()` to accomplish this.
 
   