### PR TITLE
562. Longest Line of Consecutive One in Matrix

### DIFF
--- a/src/main/java/algorithms/curated170/medium/LongestLineOfConsecutiveOneInMatrix.java
+++ b/src/main/java/algorithms/curated170/medium/LongestLineOfConsecutiveOneInMatrix.java
@@ -1,0 +1,140 @@
+package algorithms.curated170.medium;
+
+import java.util.Arrays;
+
+public class LongestLineOfConsecutiveOneInMatrix {
+
+    final int VERTICAL = 0b10;
+    final int HORIZONTAL = 0b100;
+    final int DIAGONAL = 0b1000;
+    final int ANTID = 0b10000;
+
+    int[][] mat;
+    int n, m;
+    int longest = 0;
+
+    public int longestLine(int[][] mat) {
+        this.mat = mat;
+        n = mat.length;
+        m = mat[0].length;
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                control(i, j);
+            }
+        }
+        return longest;
+    }
+
+    void control(int i, int j) {
+        int curr = mat[i][j];
+        if (!hasFlag(curr, VERTICAL)) {
+            goVertical(i, j, 1);
+        }
+        if (!hasFlag(curr, HORIZONTAL)) {
+            goHorizontal(i, j, 1);
+        }
+        if (!hasFlag(curr, DIAGONAL)) {
+            goDiagonal(i, j, 1);
+        }
+        if (!hasFlag(curr, ANTID)) {
+            goAntidiagonal(i, j, 1);
+        }
+    }
+
+    boolean hasFlag(int curr, int flag) {
+        if (curr < 1) {
+            return true;
+        }
+        if (flag == VERTICAL) {
+            int shift = flag & curr;
+            if ((shift >> 1) > 0) {
+                return true;
+            }
+            return false;
+        } else if (flag == HORIZONTAL) {
+            int shift = flag & curr;
+            if ((shift >> 2) > 0) {
+                return true;
+            }
+            return false;
+        } else if (flag == DIAGONAL) {
+            int shift = flag & curr;
+            if ((shift >> 3) > 0) {
+                return true;
+            }
+            return false;
+        }
+        else if (flag == ANTID) {
+            int shift = flag & curr;
+            if ((shift >> 4) > 0) {
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    void goDiagonal(int i, int j, int length) {
+        if (j >= m || i >= n || mat[i][j] < 1) {
+            return;
+        }
+        longest = Math.max(longest, length);
+        mat[i][j] |= DIAGONAL;
+        goDiagonal(i + 1, j + 1, length + 1);
+    }
+
+    void goAntidiagonal(int i, int j, int length) {
+        if (j < 0 || i >= n || mat[i][j] < 1) {
+            return;
+        }
+        longest = Math.max(longest, length);
+        mat[i][j] |= ANTID;
+        goAntidiagonal(i + 1, j - 1, length + 1);
+    }
+
+    void goVertical(int i, int j, int length) {
+        if (j >= m || mat[i][j] < 1) {
+            return;
+        }
+
+        longest = Math.max(longest, length);
+        mat[i][j] |= VERTICAL;
+        goVertical(i, j + 1, length + 1);
+    }
+
+    void goHorizontal(int i, int j, int length) {
+        if (i >= n || mat[i][j] < 1) {
+            return;
+        }
+        longest = Math.max(longest, length);
+        mat[i][j] |= HORIZONTAL;
+        goHorizontal(i + 1, j, length + 1);
+    }
+
+    public static void main(String[] args) {
+        int[][] mat = new int[][] { { 1, 1, 1, 0, 0 }, { 0, 1, 1, 0, 0 }, { 0, 0, 1, 0, 1 }, { 0, 0, 0, 1, 0 }, };
+        var solution = new LongestLineOfConsecutiveOneInMatrix();
+        /*
+         * int k = 0b11; System.out.println(solution.hasFlag(k, solution.vertical)); k =
+         * 0b101; System.out.println(solution.hasFlag(k, solution.vertical)); k = 1;
+         * System.out.println(solution.hasFlag(k, solution.vertical));
+         */
+        System.out.println(solution.longestLine(mat));
+
+        mat = new int[][] { 
+                { 1, 1, 0, 0, 1, 0, 0, 1, 1, 0 },
+                { 1, 0, 0, 1, 0, 1, 1, 1, 1, 1 },
+                { 1, 1, 1, 0, 0, 1, 1, 1, 1, 0 }, 
+                { 0, 1, 1, 1, 0, 1, 1, 1, 1, 1 }, 
+                { 0, 0, 1, 1, 1, 1, 1, 1, 1, 0 },
+                { 1, 1, 1, 1, 1, 1, 0, 1, 1, 1 }, 
+                { 0, 1, 1, 1, 1, 1, 1, 0, 0, 1 }, 
+                { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1 },
+                { 0, 1, 0, 1, 1, 0, 1, 1, 1, 1 }, 
+                { 1, 1, 1, 0, 1, 0, 1, 1, 1, 1 } };
+
+        System.out.println(solution.longestLine(mat));
+        
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/LongestLineOfConsecutiveOneInMatrix.java
+++ b/src/main/java/algorithms/curated170/medium/LongestLineOfConsecutiveOneInMatrix.java
@@ -1,13 +1,18 @@
 package algorithms.curated170.medium;
 
 import java.util.Arrays;
+import java.util.BitSet;
 
 public class LongestLineOfConsecutiveOneInMatrix {
 
-    final int VERTICAL = 0b10;
-    final int HORIZONTAL = 0b100;
-    final int DIAGONAL = 0b1000;
-    final int ANTID = 0b10000;
+    final int X_DIR = 0;
+    final int Y_DIR = 1;
+    final int BIT_FLAG = 2;
+    final int[] vertical = new int[] { 0, 1, 0b10 };
+    final int[] horizontal = new int[] { 1, 0, 0b100 };
+    final int[] diagonal = new int[] { 1, 1, 0b1000 };
+    final int[] antidiagonal = new int[] { 1, -1, 0b10000 };
+    final int[][] DIRECTIONS = new int[][] { null, vertical, horizontal, diagonal, antidiagonal };
 
     int[][] mat;
     int n, m;
@@ -20,106 +25,53 @@ public class LongestLineOfConsecutiveOneInMatrix {
 
         for (int i = 0; i < n; i++) {
             for (int j = 0; j < m; j++) {
-                control(i, j);
+                exploreTile(i, j);
             }
         }
         return longest;
     }
 
-    void control(int i, int j) {
-        int curr = mat[i][j];
-        if (!hasFlag(curr, VERTICAL)) {
-            goVertical(i, j, 1);
+    void exploreTile(int i, int j) {
+        final int TILE_VAL = mat[i][j];
+        if (TILE_VAL < 1) {
+            return;
         }
-        if (!hasFlag(curr, HORIZONTAL)) {
-            goHorizontal(i, j, 1);
-        }
-        if (!hasFlag(curr, DIAGONAL)) {
-            goDiagonal(i, j, 1);
-        }
-        if (!hasFlag(curr, ANTID)) {
-            goAntidiagonal(i, j, 1);
+        for (int flagIndex = 1; flagIndex <= 4; flagIndex++) {
+            if (!hasFlag(TILE_VAL, flagIndex)) {
+                goInDir(i, j, 1, DIRECTIONS[flagIndex]);
+            }
         }
     }
 
-    boolean hasFlag(int curr, int flag) {
-        if (curr < 1) {
+    boolean hasFlag(final int TILE_VAL, final int FLAG_INDEX) {
+
+        final int FLAG = DIRECTIONS[FLAG_INDEX][BIT_FLAG];
+        final int VAL_ON_FLAG = FLAG & TILE_VAL;
+        if ((VAL_ON_FLAG >> FLAG_INDEX) != 0) {
             return true;
-        }
-        if (flag == VERTICAL) {
-            int shift = flag & curr;
-            if ((shift >> 1) > 0) {
-                return true;
-            }
-            return false;
-        } else if (flag == HORIZONTAL) {
-            int shift = flag & curr;
-            if ((shift >> 2) > 0) {
-                return true;
-            }
-            return false;
-        } else if (flag == DIAGONAL) {
-            int shift = flag & curr;
-            if ((shift >> 3) > 0) {
-                return true;
-            }
-            return false;
-        }
-        else if (flag == ANTID) {
-            int shift = flag & curr;
-            if ((shift >> 4) > 0) {
-                return true;
-            }
-            return false;
         }
         return false;
     }
 
-    void goDiagonal(int i, int j, int length) {
-        if (j >= m || i >= n || mat[i][j] < 1) {
-            return;
-        }
-        longest = Math.max(longest, length);
-        mat[i][j] |= DIAGONAL;
-        goDiagonal(i + 1, j + 1, length + 1);
-    }
+    void goInDir(int i, int j, int length, final int[] DIR) {
 
-    void goAntidiagonal(int i, int j, int length) {
-        if (j < 0 || i >= n || mat[i][j] < 1) {
-            return;
-        }
-        longest = Math.max(longest, length);
-        mat[i][j] |= ANTID;
-        goAntidiagonal(i + 1, j - 1, length + 1);
-    }
-
-    void goVertical(int i, int j, int length) {
-        if (j >= m || mat[i][j] < 1) {
+        if (j < 0 || j >= m || i >= n || mat[i][j] < 1) {
             return;
         }
 
         longest = Math.max(longest, length);
-        mat[i][j] |= VERTICAL;
-        goVertical(i, j + 1, length + 1);
-    }
-
-    void goHorizontal(int i, int j, int length) {
-        if (i >= n || mat[i][j] < 1) {
-            return;
-        }
-        longest = Math.max(longest, length);
-        mat[i][j] |= HORIZONTAL;
-        goHorizontal(i + 1, j, length + 1);
+        mat[i][j] |= DIR[BIT_FLAG];
+        goInDir(i + DIR[X_DIR], j + DIR[Y_DIR], length + 1, DIR);
     }
 
     public static void main(String[] args) {
-        int[][] mat = new int[][] { { 1, 1, 1, 0, 0 }, { 0, 1, 1, 0, 0 }, { 0, 0, 1, 0, 1 }, { 0, 0, 0, 1, 0 }, };
+        int[][] mat = new int[][] { { 1, 1, 1, 0, 0 },
+                                    { 0, 1, 1, 0, 0 }, 
+                                    { 0, 0, 1, 0, 1 }, 
+                                    { 0, 0, 0, 1, 0 }, };
+                                    
         var solution = new LongestLineOfConsecutiveOneInMatrix();
-        /*
-         * int k = 0b11; System.out.println(solution.hasFlag(k, solution.vertical)); k =
-         * 0b101; System.out.println(solution.hasFlag(k, solution.vertical)); k = 1;
-         * System.out.println(solution.hasFlag(k, solution.vertical));
-         */
+        
         System.out.println(solution.longestLine(mat));
 
         mat = new int[][] { 

--- a/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixBitflags.java
+++ b/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixBitflags.java
@@ -6,11 +6,11 @@ public class LongestLineOfConsecutiveOneInMatrixBitflags {
     final int Y_DIR = 1;
     final int BIT_FLAG = 2;
     
-    final int[] vertical = new int[] { 0, 1, 0b10 };
-    final int[] horizontal = new int[] { 1, 0, 0b100 };
-    final int[] diagonal = new int[] { 1, 1, 0b1000 };
-    final int[] antidiagonal = new int[] { 1, -1, 0b10000 };
-    final int[][] DIRECTIONS = new int[][] { null, vertical, horizontal, diagonal, antidiagonal };
+    final int[] VERTICAL = new int[] { 0, 1, 0b10 };
+    final int[] HORIZONTAL = new int[] { 1, 0, 0b100 };
+    final int[] DIAGONAL = new int[] { 1, 1, 0b1000 };
+    final int[] ANTIDIAGONAL = new int[] { 1, -1, 0b10000 };
+    final int[][] DIRECTIONS = new int[][] { null, VERTICAL, HORIZONTAL, DIAGONAL, ANTIDIAGONAL };
 
     int[][] mat;
     int n, m;

--- a/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixBitflags.java
+++ b/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixBitflags.java
@@ -1,13 +1,11 @@
 package algorithms.curated170.medium;
 
-import java.util.Arrays;
-import java.util.BitSet;
-
-public class LongestLineOfConsecutiveOneInMatrix {
+public class LongestLineOfConsecutiveOneInMatrixBitflags {
 
     final int X_DIR = 0;
     final int Y_DIR = 1;
     final int BIT_FLAG = 2;
+    
     final int[] vertical = new int[] { 0, 1, 0b10 };
     final int[] horizontal = new int[] { 1, 0, 0b100 };
     final int[] diagonal = new int[] { 1, 1, 0b1000 };
@@ -70,7 +68,7 @@ public class LongestLineOfConsecutiveOneInMatrix {
                                     { 0, 0, 1, 0, 1 }, 
                                     { 0, 0, 0, 1, 0 }, };
                                     
-        var solution = new LongestLineOfConsecutiveOneInMatrix();
+        var solution = new LongestLineOfConsecutiveOneInMatrixBitflags();
         
         System.out.println(solution.longestLine(mat));
 
@@ -78,13 +76,13 @@ public class LongestLineOfConsecutiveOneInMatrix {
                 { 1, 1, 0, 0, 1, 0, 0, 1, 1, 0 },
                 { 1, 0, 0, 1, 0, 1, 1, 1, 1, 1 },
                 { 1, 1, 1, 0, 0, 1, 1, 1, 1, 0 }, 
-                { 0, 1, 1, 1, 0, 1, 1, 1, 1, 1 }, 
+                { 0, 1, 1, 1, 0, 1, 1, 1, 1, 0 }, 
                 { 0, 0, 1, 1, 1, 1, 1, 1, 1, 0 },
                 { 1, 1, 1, 1, 1, 1, 0, 1, 1, 1 }, 
                 { 0, 1, 1, 1, 1, 1, 1, 0, 0, 1 }, 
                 { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1 },
                 { 0, 1, 0, 1, 1, 0, 1, 1, 1, 1 }, 
-                { 1, 1, 1, 0, 1, 0, 1, 1, 1, 1 } };
+                { 0, 1, 1, 0, 1, 0, 1, 1, 1, 1 } };
 
         System.out.println(solution.longestLine(mat));
         

--- a/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixChecking.java
+++ b/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixChecking.java
@@ -1,0 +1,88 @@
+package algorithms.curated170.medium;
+
+public class LongestLineOfConsecutiveOneInMatrixChecking {
+
+    final int[] VERTICAL = new int[] { 0, 1 };
+    final int[] HORIZONTAL = new int[] { 1, 0 };
+    final int[] DIAGONAL = new int[] { 1, 1 };
+    final int[] ANTIDIAGONAL = new int[] { 1, -1 };
+
+    int n, m;
+
+    public int longestLine(int[][] mat) {
+
+        int max = 0;
+        n = mat.length;
+        m = mat[0].length;
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+
+                if (mat[i][j] == 0) {
+                    continue;
+                }
+
+                if (j == 0 || mat[i][j - 1] == 0) {
+                    max = Math.max(max, explore(VERTICAL, i, j, mat));
+                }
+
+                if (i == 0 || mat[i - 1][j] == 0) {
+                    max = Math.max(max, explore(HORIZONTAL, i, j, mat));
+                }
+
+                if (i == 0 || j == 0 || mat[i - 1][j - 1] == 0) {
+                    max = Math.max(max, explore(DIAGONAL, i, j, mat));
+                }
+
+                if (i == 0 || j == m - 1 || mat[i - 1][j + 1] == 0) {
+                    max = Math.max(max, explore(ANTIDIAGONAL, i, j, mat));
+                }
+            }
+        }
+
+        return max;
+    }
+
+    public int explore(int[] dir, int i, int j, int[][] mat) {
+        
+        int count = 0;
+
+        while (isOnGridAndOne(i, j, mat)) {
+            count++;
+            i += dir[0];
+            j += dir[1];
+        }
+
+        return count;
+    }
+
+    private boolean isOnGridAndOne(int i, int j, int[][] mat) {
+        return i >= 0 && i < n && j >= 0 && j < m && mat[i][j] != 0;
+    }
+
+    public static void main(String[] args) {
+        int[][] mat = new int[][] { { 1, 1, 1, 0, 0 },
+                                    { 0, 1, 1, 0, 0 }, 
+                                    { 0, 0, 1, 0, 1 }, 
+                                    { 0, 0, 0, 1, 0 }, };
+                                    
+        var solution = new LongestLineOfConsecutiveOneInMatrixChecking();
+        
+        System.out.println(solution.longestLine(mat));
+
+        mat = new int[][] { 
+                { 1, 1, 0, 0, 1, 0, 0, 1, 1, 0 },
+                { 1, 0, 0, 1, 0, 1, 1, 1, 1, 1 },
+                { 1, 1, 1, 0, 0, 1, 1, 1, 1, 0 }, 
+                { 0, 1, 1, 1, 0, 1, 1, 1, 1, 0 }, 
+                { 0, 0, 1, 1, 1, 1, 1, 1, 1, 0 },
+                { 1, 1, 1, 1, 1, 1, 0, 1, 1, 1 }, 
+                { 0, 1, 1, 1, 1, 1, 1, 0, 0, 1 }, 
+                { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1 },
+                { 0, 1, 0, 1, 1, 0, 1, 1, 1, 1 }, 
+                { 0, 1, 1, 0, 1, 0, 1, 1, 1, 1 } };
+
+        System.out.println(solution.longestLine(mat));
+        
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixDP.java
+++ b/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixDP.java
@@ -11,8 +11,8 @@ public class LongestLineOfConsecutiveOneInMatrixDP {
         
         int horizontal = 0;
         int[] vertical = new int[m];
-        int[] diagonal = new int[n + m];
         int[] antiDiagonal = new int[n + m];
+        int[] diagonal = new int[n + m];
 
         for (int i = 0; i < n; i++) {
             horizontal = 0;    
@@ -20,19 +20,19 @@ public class LongestLineOfConsecutiveOneInMatrixDP {
                 if (mat[i][j] != 1) {
                     horizontal = 0;
                     vertical[j] = 0;
-                    diagonal[j + i] = 0;
-                    antiDiagonal[j - i + n] = 0;
+                    antiDiagonal[j + i] = 0;
+                    diagonal[j - i + n] = 0;
                     continue;
                 }
 
                 horizontal++;
                 vertical[j]++;
-                diagonal[j + i]++;
-                antiDiagonal[j - i + n]++;
+                antiDiagonal[j + i]++;
+                diagonal[j - i + n]++;
                 max = Math.max(max, horizontal);
                 max = Math.max(max, vertical[j]);
-                max = Math.max(max, diagonal[j + i]);
-                max = Math.max(max, antiDiagonal[j - i + n]);
+                max = Math.max(max, antiDiagonal[j + i]);
+                max = Math.max(max, diagonal[j - i + n]);
             }
         }
         return max;

--- a/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixDP.java
+++ b/src/main/java/algorithms/curated170/medium/longestlineofconsecutiveoneinmatrix/LongestLineOfConsecutiveOneInMatrixDP.java
@@ -1,0 +1,66 @@
+package algorithms.curated170.medium;
+
+public class LongestLineOfConsecutiveOneInMatrixDP {
+
+    public int longestLine(int[][] mat) {
+
+        int m = mat[0].length;
+        int n = mat.length;
+        
+        int max = 0;
+        
+        int horizontal = 0;
+        int[] vertical = new int[m];
+        int[] diagonal = new int[n + m];
+        int[] antiDiagonal = new int[n + m];
+
+        for (int i = 0; i < n; i++) {
+            horizontal = 0;    
+            for (int j = 0; j < m; j++) {
+                if (mat[i][j] != 1) {
+                    horizontal = 0;
+                    vertical[j] = 0;
+                    diagonal[j + i] = 0;
+                    antiDiagonal[j - i + n] = 0;
+                    continue;
+                }
+
+                horizontal++;
+                vertical[j]++;
+                diagonal[j + i]++;
+                antiDiagonal[j - i + n]++;
+                max = Math.max(max, horizontal);
+                max = Math.max(max, vertical[j]);
+                max = Math.max(max, diagonal[j + i]);
+                max = Math.max(max, antiDiagonal[j - i + n]);
+            }
+        }
+        return max;
+    }
+
+    public static void main(String[] args) {
+        int[][] mat = new int[][] { { 1, 1, 1, 0, 0 },
+                                    { 0, 1, 1, 0, 0 }, 
+                                    { 0, 0, 1, 0, 1 }, 
+                                    { 0, 0, 0, 1, 0 }, };
+                                    
+        var solution = new LongestLineOfConsecutiveOneInMatrixDP();
+        
+        System.out.println(solution.longestLine(mat));
+
+        mat = new int[][] { 
+                { 1, 1, 0, 0, 1, 0, 0, 1, 1, 0 },
+                { 1, 0, 0, 1, 0, 1, 1, 1, 1, 1 },
+                { 1, 1, 1, 0, 0, 1, 1, 1, 1, 0 }, 
+                { 0, 1, 1, 1, 0, 1, 1, 1, 1, 0 }, 
+                { 0, 0, 1, 1, 1, 1, 1, 1, 1, 0 },
+                { 1, 1, 1, 1, 1, 1, 0, 1, 1, 1 }, 
+                { 0, 1, 1, 1, 1, 1, 1, 0, 0, 1 }, 
+                { 1, 1, 1, 1, 1, 0, 0, 1, 1, 1 },
+                { 0, 1, 0, 1, 1, 0, 1, 1, 1, 1 }, 
+                { 0, 1, 1, 0, 1, 0, 1, 1, 1, 1 } };
+
+        System.out.println(solution.longestLine(mat));
+        
+    }
+}


### PR DESCRIPTION
Resolves: #68 

## Algorithm:
In each tile that is 1, we can count the lengths of the vertical, horizontal, diagonal and anti-diagonal lines at that point by incrementing the two position indices for the respective movement operation and counting until we hit a 0 or matrix bounds.

### Approach 1-Dynamic Programming:
Similar to #313, in a row, we can count the number of consecutive Ones, accumulating along the way. If we hit a 0, we reset this counter. 
We can also accumulate the horizontal consecutive length between the rows. Since we don't directly iterate through this path, we need an array to keep track of this.

For the diagonal, we need to check the previous column in the next row. When we get to the next row at there, the row has been incremented by 1 and the column is decremented by 1. Let's say that we are going to check this relationship at row = 1, and column 0. In the tile anti-diagonally before, the row was 0 and the column was 1. That means that in this relationship, the sum of row and column stay constant with the column always increasing. So, when storing our 1 at some position `i, j`, we store it at `i+j`.

For the diagonal, unlike in the horizontal, we accumulate for the next column, since that is going to be consecutive to the current one. Next diagonal of` i=2,  j=3` is `i=3,  j=4`. Here, `j-i` stands constant. Since, this can be smaller than 0, we add the size of the array to it to index it. We accumulate our count there.

We compare the current counts and pick the maximums among them and eventually return.

### Approach 2-Bit Flags:
Since we have a grid, we can modify it as well.
Let's say that the 2nd bit of some number at the grid denotes if it has been vertically visited. So, 3rd:horizontal, 4th:diagonal, 5th: anti-diagonal.
For example, this is some number from the grid in binary.
`010011`
It has been vertically and anti-diagonally visited. Since when we visit a tile, we also move on to its possible neighbor in the same direction, we don't explore through such notes in the directions where it has been bitwise-flagged.
When we are moving in some direction, we flag all the notes at the bit of that direction.
This way, we only use constant amount of space.

### Approach 3-Checking the Previous Tile:
Like in #315, having a previous tile being one in any of these four directions means that we have previously visited this current tile by the means of that previous tile, so we should not go in its direction. This approach also uses only constant space and doesn't modify the matrix.