### PR TITLE
255. Verify Preorder Sequence in Binary Search Tree

### DIFF
--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
@@ -13,7 +13,7 @@ public class VerifyPreorderSequenceInBinaryTreeDFS {
     }
 
     private void DFS(int[] preorder, int lower, int upper) {
-        if (i >= preorder.length || preorder[i] < lower || preorder[i] > upper) {
+        if (i == preorder.length || preorder[i] < lower || preorder[i] > upper) {
             return;
         }
 

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
@@ -5,15 +5,17 @@ import java.util.Stack;
 public class VerifyPreorderSequenceInBinaryTreeDFS {
 
     int i;
+
     public boolean verifyPreorder(int[] preorder) {
+        i = 0;
         DFS(preorder, Integer.MIN_VALUE, Integer.MAX_VALUE);
         return i == preorder.length;
     }
 
-    private void DFS(int[] preorder,int lower, int upper )
-    {
-        if (i >= preorder.length || preorder[i] < lower || preorder[i] > upper)
-        return;
+    private void DFS(int[] preorder, int lower, int upper) {
+        if (i >= preorder.length || preorder[i] < lower || preorder[i] > upper) {
+            return;
+        }
 
         int val = preorder[i++];
         DFS(preorder, lower, val);

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
@@ -1,0 +1,22 @@
+package algorithms.curated170.medium.verifypreordersequenceinbinarytree;
+
+import java.util.Stack;
+
+public class VerifyPreorderSequenceInBinaryTreeDFS {
+
+    int i;
+    public boolean verifyPreorder(int[] preorder) {
+        DFS(preorder, Integer.MIN_VALUE, Integer.MAX_VALUE);
+        return i == preorder.length;
+    }
+
+    private void DFS(int[] preorder,int lower, int upper )
+    {
+        if (i >= preorder.length || preorder[i] < lower || preorder[i] > upper)
+        return;
+
+        int val = preorder[i++];
+        DFS(preorder, lower, val);
+        DFS(preorder, val, upper);
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeDFS.java
@@ -1,7 +1,5 @@
 package algorithms.curated170.medium.verifypreordersequenceinbinarytree;
 
-import java.util.Stack;
-
 public class VerifyPreorderSequenceInBinaryTreeDFS {
 
     int i;

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeModifyInputArray.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeModifyInputArray.java
@@ -1,7 +1,5 @@
 package algorithms.curated170.medium.verifypreordersequenceinbinarytree;
 
-import java.util.Stack;
-
 public class VerifyPreorderSequenceInBinaryTreeModifyInputArray {
 
     public boolean verifyPreorder(int[] preorder) {

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeModifyInputArray.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeModifyInputArray.java
@@ -1,0 +1,21 @@
+package algorithms.curated170.medium.verifypreordersequenceinbinarytree;
+
+import java.util.Stack;
+
+public class VerifyPreorderSequenceInBinaryTreeModifyInputArray {
+
+    public boolean verifyPreorder(int[] preorder) {
+        int lowest = Integer.MIN_VALUE, i = -1;
+        for (int n : preorder) {
+            if (n < lowest) {
+                return false;
+            }
+            while (i >= 0 && n > preorder[i]) {
+                lowest = preorder[i--];
+            }
+            preorder[++i] = n;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeStack.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeStack.java
@@ -1,0 +1,21 @@
+package algorithms.curated170.medium.verifypreordersequenceinbinarytree;
+
+import java.util.Stack;
+
+public class VerifyPreorderSequenceInBinaryTreeStack {
+
+    public boolean verifyPreorder(int[] preorder) {
+        Stack<Integer> stack = new Stack<>();
+        int lowest = Integer.MIN_VALUE;
+        for (int n : preorder) {
+            if (n < lowest) {
+                return false;
+            }
+            while (!stack.isEmpty() && n > stack.peek()) {
+                lowest = stack.pop();
+            }
+            stack.push(n);
+        }
+        return true;
+    }
+}

--- a/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeStack.java
+++ b/src/main/java/algorithms/curated170/medium/verifypreordersequenceinbinarytree/VerifyPreorderSequenceInBinaryTreeStack.java
@@ -18,4 +18,14 @@ public class VerifyPreorderSequenceInBinaryTreeStack {
         }
         return true;
     }
+
+    public static void main(String[] args) {
+        var solution = new VerifyPreorderSequenceInBinaryTreeStack();
+        int[] preorder = {5,2,1,3,4,7,6,9};
+        
+        System.out.println(solution.verifyPreorder(preorder)); // true
+
+        preorder = new int[]{5,2,1,3,-1,7,6,9}; 
+        System.out.println(solution.verifyPreorder(preorder)); // false
+    }
 }


### PR DESCRIPTION
Resolves: #69 

## Algorithm:

### Approach 1-Stack:
Here, we are going to scrutinize how the preorder sequence of this tree comes about:
![image](https://user-images.githubusercontent.com/63192680/121849851-8f1c1180-ccf4-11eb-956a-e89bbd5f704b.png)

Consider the sequence `5, 2, 1` :
Since the values are always going down, it means that we have a BST that is always going left. 
Now consider adding 3 to this sequence -> `5, 2, 1, 3`:
Is this now a valid preorder sequence? 3 cannot be the right child of 1. This doesn't mean that it is not a valid preorder sequence. Perhaps 3 is the child of the node before 1, which is 2. In our case, this yields a valid preorder sequence. Since we have now switched from the left branch of the node 2 to its right branch, we won't need to use this 1 as a possible parent value. For this, we use a stack where we first check if a value is smaller than the peeked value, otherwise pop this value to make it our lower bound, until we hit a peeked value that is larger than the current value.

Now consider something that would violate this preorder sequence, such as adding -1 -> `5, 2, 1, 3, -1` :
Since 3 is the right node of the node 2, we can't have values smaller than 2 in the child nodes of 3. This means that when we are checking the right branch of some node, the values in the right branch are bounded from below by the values of the node, in our case 2. Then let's go back considering how a sequence is valid and replace this -1 with a valid value of 4 -> `5, 2, 1, 3, 4` :
Here, our stack is `{5, 3}` . We had popped 1 and 2 when we checked 3. 4 is larger than 3, so we pop 3 to make it our lower bound. 5 is larger than 4, so we end the loop. We push 4 into the stack -> `{5, 4}` .
Now consider 7 also being at the end of this sequence -> `5, 2, 1, 3, 4, 7` . This is still a valid sequence, as 7 can be the right child of 5. We peek and see that 3 is lower than 7, we pop it out. But then we see that 5 is lower than 7. We also pop it out and make it our lower bound. The stack is now this: `{7}` .
For the rest of the sequence that would be  `5, 2, 1, 3, 4, 7, 6, 9`  : 6 does not exceed our lower bound. At 9, we pop out 6 and 7 to switch to the right branch and find that 7 is the lower bound. We don't have any elements left in the array and we haven't come across any invalid sequences, so we return true.

### Approach 2-Using the Input Array as Stack:
Since the number of items in the stack is always less than the index we are at in the array, we can overwrite the previous elements in the array. For the previous example, at the value 3, the number at the previous index is not the parent of 3, so we go back one more index. 2 is the parent of 3. So make it our lower bound and overwrite it as the possible parent of the next nodes. Like this `[5, 3, 1, 3, 4, ...]`, where some index `i=1`, denotes the index of the value we are peeking at from the stack. 
At 4, our value is larger than 3. So we make 3 the lower bound and replace it with 4:
 `[5, 4, 1, 3, 4, 7, ...]`

At 7, we go back 2 indices and make 5 our lower bound, replacing it with 7 as the new parent
 `[7, 4, 1, 3, 4, 7, 6, 9]

At 6, we just insert it as it is to the left of the peeked value:
 `[7, 6, 1, 3, 4, 7, 6, 9]`

At 9, we go back 2 indices and make 7 our lower bound, replacing it with 9 as the new parent
 `[9, 6, 1, 3, 4, 7, 6, 9]`

We have never encountered a value that exceeds the lower bound, so we return true.

### Approach 3-DFS through the Possible Valid Sequence:
In a binary search tree, our values technically have an upper and a lower bound as ths:
![image](https://user-images.githubusercontent.com/63192680/121851881-5cbfe380-ccf7-11eb-91c2-c50517a7aee1.png)

At each element of the sequence, we can try if it is the replaces the lower bound or the upper bound. We won't have any extra branches in our guesses as invalid ones immediately fail. If we somehow try through all elements in the array without failing, that means that we have valid preorder sequence. 