### PR TITLE
1088. Confusing Number II

### DIFF
--- a/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
+++ b/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
@@ -21,11 +21,11 @@ public class ConfusingNumber2 {
     private int findTotal(String s) {
         if (s.length() == 0) return 1;
         char first = s.charAt(0);
-        int res = count(first) * (int) (Math.pow(5, s.length() - 1));
+        int reflectivePermutations = count(first) * (int) (Math.pow(5, s.length() - 1));
         if (first == '0' || first == '1' || first == '6' || first == '8' || first == '9') {
-            res += findTotal(s.substring(1));
+            reflectivePermutations += findTotal(s.substring(1));
         }
-        return res;
+        return reflectivePermutations;
     }
     private int count(Character c) {
         int res = 0;

--- a/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
+++ b/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
@@ -1,0 +1,42 @@
+package algorithms.curated170.hard;
+
+import algorithms.hard.StrobogrammaticNumber3;
+
+ 
+public class ConfusingNumber2 {
+   final char[][] reflectives = new char[][]{
+        {'0', '0'},
+        {'6', '9'},
+        {'1', '1'},
+        {'9', '6'},
+        {'8', '8'}
+    };
+
+    int highLen;
+    int lowLen;
+    int currLen;
+    
+    public int confusingNumberII(int n) {
+        String num = Integer.toString(n);
+        int res = findTotal(num);
+        StrobogrammaticNumber3 strobogrammaticNumber = new StrobogrammaticNumber3();
+        return res - strobogrammaticNumber.strobogrammaticInRange("1", num) - 1;
+    }
+    private int findTotal(String s) {
+        if (s.length() == 0) return 1;
+        char first = s.charAt(0);
+        int res = count(first) * (int) (Math.pow(5, s.length() - 1));
+        if (first == '0' || first == '1' || first == '6' || first == '8' || first == '9') {
+            res += findTotal(s.substring(1));
+        }
+        return res;
+    }
+    private int count(Character c) {
+        int res = 0;
+        for (char[] p : reflectives) {
+            if (p[0] < c) res += 1;
+        }
+        return res;
+    }
+    
+}

--- a/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
+++ b/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
@@ -11,10 +11,6 @@ public class ConfusingNumber2 {
         {'9', '6'},
         {'8', '8'}
     };
-
-    int highLen;
-    int lowLen;
-    int currLen;
     
     public int confusingNumberII(int n) {
         String num = Integer.toString(n);

--- a/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
+++ b/src/main/java/algorithms/curated170/hard/ConfusingNumber2.java
@@ -30,7 +30,7 @@ public class ConfusingNumber2 {
     private int count(Character c) {
         int res = 0;
         for (char[] p : reflectives) {
-            if (p[0] < c) res += 1;
+            if (p[0] < c) res ++;
         }
         return res;
     }


### PR DESCRIPTION
Resolves: https://github.com/spiralgo/algorithms/issues/228

As we understand here: https://github.com/spiralgo/algorithms/issues/156, if a number is generated using the numbers: 0, 1, 6, 8, 9 and :

 - if it does `not equal` itself when it is rotated 180 degrees, it is a `confusing number`. 
 
 - If it `equals` itself when it is rotated 180 degrees, it is a `strobogrammatic number`. 
 
 Therefore:

>  (Total numbers) - (strobogrammatic numbers) = (confusing numbers)

It means, we can use the code here https://github.com/spiralgo/algorithms/pull/323, and just subtract its output from the total count of all numbers generated using 0, 1, 6, 8, 9.


 