### PR TITLE
285. Inorder Successor in BST

### DIFF
--- a/src/main/java/algorithms/curated170/medium/inordersuccessorinbst/InorderSuccessorInBSTDFS.java
+++ b/src/main/java/algorithms/curated170/medium/inordersuccessorinbst/InorderSuccessorInBSTDFS.java
@@ -1,0 +1,20 @@
+package algorithms.curated170.medium.findrootofnarytree;
+
+import algorithms.datastructures.TreeNode;
+
+public class InorderSuccessorInBSTDFS {
+
+    public TreeNode inorderSuccessor(TreeNode root, TreeNode p) {
+        if (root == null) {
+            return null;
+        }
+
+        if (root.val <= p.val) {
+            return inorderSuccessor(root.right, p);
+        } else {
+            TreeNode successor = inorderSuccessor(root.left, p);
+            return (successor != null) ? successor : root;
+        }
+    }
+
+}

--- a/src/main/java/algorithms/curated170/medium/inordersuccessorinbst/InorderSuccessorInBSTIterative.java
+++ b/src/main/java/algorithms/curated170/medium/inordersuccessorinbst/InorderSuccessorInBSTIterative.java
@@ -1,0 +1,22 @@
+package algorithms.curated170.medium.findrootofnarytree;
+
+import algorithms.datastructures.TreeNode;
+
+public class InorderSuccessorInBSTIterative {
+
+    public TreeNode inorderSuccessor(TreeNode root, TreeNode p) {
+
+        TreeNode successor = null;
+
+        while (root != null) {
+            if (p.val < root.val) {
+                successor = root;
+                root = root.left;
+            } else {
+                root = root.right;
+            }
+        }
+
+        return successor;
+    }
+}


### PR DESCRIPTION
Resolves: #78 

## Algorithm:
The inorder successor of a node in a binary search tree is basically the smallest node that has a larger value than the node's. If it's a left node and it has no right nodes, its successor would be its parent. If it has a right node, it is this if the right node does not have any left nodes, which would have been smaller than this right node. If right node does have a left node, it is the left most, so the smallest node on that side. 

![image](https://user-images.githubusercontent.com/63192680/122257840-0f02d100-ced9-11eb-9f79-0a3ccb4dd114.png)
where p=3:

Hence, if the given root's value is larger than the node's, we go down the tree, updating successor to point to root, then the left, up until we encounter a node that is greater or equal to the given previous node, this case let it be the given previous node. At that point, the successor is either the parent that we have marked, or some node to its right. It indeed has a node to its right, so its successor is not 6 as we have previously marked, but 5. We then see that 5 has a left node too. We then mark our successor to be 4, but it has a left node too, we then mark this to be the successor. So the successor here is 3.2*.

What we also did here was that our root, selected node, was at some point smaller than the value we were looking for (when we are at 3). In such a case, we go right and then left if possible.

In the DFS solution, we achieve this by calling the method with the root, basically the selected node, being either the right or the left. When we find the node, it having no right nodes, the right being null, or when we try to go left end find a null node, would mean that we have to return its parent.


*I am aware that we are working with the integers. But this makes the example valid too.