### PR TITLE
305. Number of Islands II

### DIFF
--- a/src/main/java/algorithms/curated170/hard/NumberofIslands2.java
+++ b/src/main/java/algorithms/curated170/hard/NumberofIslands2.java
@@ -6,60 +6,67 @@ import java.util.List;
  
 public class NumberofIslands2 {
  
-    public final static int[][] DIRECTIONS = {{0,-1}, {0, 1}, {-1,0}, {1, 0}};
+    public final static int[][] DIRECTIONS = { { 0, -1 }, { 0, 1 }, { -1, 0 }, { 1, 0 } };
     int m = 0, n = 0;
     int totalNode = 0;
     int roots[];
-    
+
     public List<Integer> numIslands2(int m, int n, int[][] positions) {
-        List<Integer> output = new ArrayList();
+        List<Integer> output = new ArrayList<>();
         this.m = m;
         this.n = n;
-        
-        roots = new int[m*n+1];
-    
-        for(int[] position : positions){
-           int nodeId = getNodeId(position[0], position[1]);
-           if(roots[nodeId] != 0) {
+        roots = new int[m * n + 1];
+
+        for (int[] position : positions) {
+            int nodeId = getNodeId(position[0], position[1]);
+            if (roots[nodeId] != 0) {
                 output.add(totalNode);
                 continue;
-           }
-           roots[nodeId] = nodeId;
-           ++totalNode;
-           countComponents(generateEdges(nodeId, position));
-           output.add(totalNode);
+            }
+
+            roots[nodeId] = nodeId;
+            ++totalNode;
+            countComponents(nodeId, generateNeigbors(nodeId, position));
+            output.add(totalNode);
         }
         return output;
     }
-    
-    int getNodeId(int x, int y){
-        return n*x + y + 1;
+
+    int getNodeId(int x, int y) {
+        return n * x + y + 1;
     }
-    
-    List<int[]> generateEdges(int nodeId, int[] position){
-         
-        List<int[]> edges = new ArrayList();
-        for(int i = 0; i<DIRECTIONS.length; i++) {
+
+    final int INVALID_VERTEX = -1;
+
+    int[] generateNeigbors(int nodeId, int[] position) {
+        int[] neighbors = new int[4];
+        for (int i = 0; i < DIRECTIONS.length; i++) {
             int x = position[0] + DIRECTIONS[i][0];
             int y = position[1] + DIRECTIONS[i][1];
-             int adjacentNodeId = getNodeId(x, y);
-            if(!isValidNode( x, y, adjacentNodeId)) continue;
-            edges.add(new int[]{nodeId, adjacentNodeId});
-         
-        }
-        return edges;
-    }
-    boolean isValidNode(int x, int y,  int adjacentNodeId){
-        return (x >= 0 && x <m && y>=0 && y<n && roots[adjacentNodeId]!=0);
-    }
-  
+            int adjacentNodeId = getNodeId(x, y);
 
-    public int countComponents(List<int[]> edges) {
-   
-        for (int[] edge : edges) {
-        
-            int r1 = findRoot(edge[0]);
-            int r2 = findRoot(edge[1]);
+            if (!isValidNode(x, y, adjacentNodeId)) {
+                neighbors[i] = INVALID_VERTEX;
+                continue;
+            }
+            neighbors[i] = adjacentNodeId;
+        }
+        return neighbors;
+    }
+
+    boolean isValidNode(int x, int y, int adjacentNodeId) {
+        return (x >= 0 && x < m && y >= 0 && y < n && roots[adjacentNodeId] != 0);
+    }
+
+    public int countComponents(int nodeId, int[] neigbors) {
+
+        for (int neighbor : neigbors) {
+
+            if (neighbor == INVALID_VERTEX) {
+                continue;
+            }
+            int r1 = findRoot(nodeId);
+            int r2 = findRoot(neighbor);
 
             if (r1 != r2) {
                 roots[r1] = r2;
@@ -81,4 +88,3 @@ public class NumberofIslands2 {
         }
     }
 }
-

--- a/src/main/java/algorithms/curated170/hard/NumberofIslands2.java
+++ b/src/main/java/algorithms/curated170/hard/NumberofIslands2.java
@@ -3,19 +3,20 @@ package algorithms.curated170.hard;
 import java.util.ArrayList;
 import java.util.List;
 
- 
 public class NumberofIslands2 {
- 
-    public final static int[][] DIRECTIONS = { { 0, -1 }, { 0, 1 }, { -1, 0 }, { 1, 0 } };
+
+    public final static int[][] DIRECTIONS = {{0, -1}, {0, 1}, {-1, 0}, {1, 0}};
     int m = 0, n = 0;
     int totalNode = 0;
     int roots[];
+    int ranks[];
 
     public List<Integer> numIslands2(int m, int n, int[][] positions) {
         List<Integer> output = new ArrayList<>();
         this.m = m;
         this.n = n;
         roots = new int[m * n + 1];
+        ranks = new int[m * n + 1];
 
         for (int[] position : positions) {
             int nodeId = getNodeId(position[0], position[1]);
@@ -25,6 +26,7 @@ public class NumberofIslands2 {
             }
 
             roots[nodeId] = nodeId;
+            ranks[nodeId] = 1;
             ++totalNode;
             countComponents(nodeId, generateNeigbors(nodeId, position));
             output.add(totalNode);
@@ -69,7 +71,13 @@ public class NumberofIslands2 {
             int r2 = findRoot(neighbor);
 
             if (r1 != r2) {
-                roots[r1] = r2;
+                if (ranks[r1] <= ranks[r2]) {
+                    roots[r1] = r2;
+                    ranks[r2] += ranks[r1];
+                } else {
+                    roots[r2] = r1;
+                    ranks[r1] += ranks[r2];
+                }
                 totalNode--;
             }
         }
@@ -78,7 +86,6 @@ public class NumberofIslands2 {
     }
 
     private int findRoot(int key) {
-       
         if (key != roots[key]) {
             roots[key] = roots[roots[key]];
             key = roots[key];

--- a/src/main/java/algorithms/curated170/hard/NumberofIslands2.java
+++ b/src/main/java/algorithms/curated170/hard/NumberofIslands2.java
@@ -1,0 +1,84 @@
+package algorithms.curated170.hard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+ 
+public class NumberofIslands2 {
+ 
+    public final static int[][] DIRECTIONS = {{0,-1}, {0, 1}, {-1,0}, {1, 0}};
+    int m = 0, n = 0;
+    int totalNode = 0;
+    int roots[];
+    
+    public List<Integer> numIslands2(int m, int n, int[][] positions) {
+        List<Integer> output = new ArrayList();
+        this.m = m;
+        this.n = n;
+        
+        roots = new int[m*n+1];
+    
+        for(int[] position : positions){
+           int nodeId = getNodeId(position[0], position[1]);
+           if(roots[nodeId] != 0) {
+                output.add(totalNode);
+                continue;
+           }
+           roots[nodeId] = nodeId;
+           ++totalNode;
+           countComponents(generateEdges(nodeId, position));
+           output.add(totalNode);
+        }
+        return output;
+    }
+    
+    int getNodeId(int x, int y){
+        return n*x + y + 1;
+    }
+    
+    List<int[]> generateEdges(int nodeId, int[] position){
+         
+        List<int[]> edges = new ArrayList();
+        for(int i = 0; i<DIRECTIONS.length; i++) {
+            int x = position[0] + DIRECTIONS[i][0];
+            int y = position[1] + DIRECTIONS[i][1];
+             int adjacentNodeId = getNodeId(x, y);
+            if(!isValidNode( x, y, adjacentNodeId)) continue;
+            edges.add(new int[]{nodeId, adjacentNodeId});
+         
+        }
+        return edges;
+    }
+    boolean isValidNode(int x, int y,  int adjacentNodeId){
+        return (x >= 0 && x <m && y>=0 && y<n && roots[adjacentNodeId]!=0);
+    }
+  
+
+    public int countComponents(List<int[]> edges) {
+   
+        for (int[] edge : edges) {
+        
+            int r1 = findRoot(edge[0]);
+            int r2 = findRoot(edge[1]);
+
+            if (r1 != r2) {
+                roots[r1] = r2;
+                totalNode--;
+            }
+        }
+
+        return totalNode;
+    }
+
+    private int findRoot(int key) {
+       
+        if (key != roots[key]) {
+            roots[key] = roots[roots[key]];
+            key = roots[key];
+            return findRoot(key);
+        } else {
+            return key;
+        }
+    }
+}
+


### PR DESCRIPTION
Resolves: https://github.com/spiralgo/algorithms/issues/234

When we add a new land; in some cases, it can decrease the total number of islands.
Because it can connect two distinct islands as a united component.

This reminds a quote by @ErdemT09, in the PR https://github.com/spiralgo/algorithms/pull/200:


> It is important to understand that:
> If a new given edge connects 2 previously discrete nodes, then the number of connected components decreases.

It means, this question can be interpreted as a variant of https://github.com/spiralgo/algorithms/pull/200 and we can use Union-find here as well.
We use almost the same code with https://github.com/spiralgo/algorithms/pull/200.
This time, instead of edge pairs of nodes, we have x, y `positions` array.
Therefore, we need to generate `edges` list using these positions.
We can interpret each tile in the grid, as a node. We need a `getNodeId `method to convert a position into a  `node-id`.
In this case, an edge is only possible between a node and its `valid ` adjacent nodes. 
It is why we need the `DIRECTIONS` array.


