### PR TITLE
1059. All Paths from Source Lead to Destination

### DIFF
--- a/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
+++ b/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
@@ -9,14 +9,14 @@ public class AllPathsfromSourceLeadToDestination {
     boolean[] visiting;
     int dest;
 
-    public boolean leadsToDestination(int n, int[][] edges, int source, int destination) {
+    public boolean leadsToDestination(int n, int[][] arcs, int source, int destination) {
         this.dest = destination;
         visiting = new boolean[n];
 
-        byte graphCreation = makeGraph(edges, n, source);
-        if (graphCreation == DEST_HAS_PATH) {
+        byte graphCreation = makeGraph(arcs, n, source);
+        if (graphCreation == DEST_HAS_ARC) {
             return false;
-        } else if (graphCreation == SOURCE_HAS_NO_PATH) {
+        } else if (graphCreation == SOURCE_HAS_NO_ARC) {
             return source == destination;
         }
 
@@ -24,20 +24,20 @@ public class AllPathsfromSourceLeadToDestination {
     }
 
     final byte GRAPH_CREATED = 1;
-    final byte DEST_HAS_PATH = 0;
-    final byte SOURCE_HAS_NO_PATH = 2;
+    final byte DEST_HAS_ARC = 0;
+    final byte SOURCE_HAS_NO_ARC = 2;
     
-    byte makeGraph(int[][] edges, int n, int source) {
+    byte makeGraph(int[][] arcs, int n, int source) {
         int[] outDegree = new int[n];
-        for (int[] edge : edges) {
-            outDegree[edge[0]]++;
+        for (int[] arc : arcs) {
+            outDegree[arc[0]]++;
         }
 
         if (outDegree[dest] > 0) {
-            return DEST_HAS_PATH;
+            return DEST_HAS_ARC;
         }
         if (outDegree[source] == 0) {
-            return SOURCE_HAS_NO_PATH;
+            return SOURCE_HAS_NO_ARC;
         }
 
         graph = new int[n][];
@@ -46,8 +46,8 @@ public class AllPathsfromSourceLeadToDestination {
         }
 
         int[] nextDirectSuccessorIndex = new int[n];
-        for (int[] edge : edges) {
-            graph[edge[0]][nextDirectSuccessorIndex[edge[0]]++] = edge[1];
+        for (int[] arc : arcs) {
+            graph[arc[0]][nextDirectSuccessorIndex[arc[0]]++] = arc[1];
         }
         return GRAPH_CREATED;
     }
@@ -59,8 +59,8 @@ public class AllPathsfromSourceLeadToDestination {
         }
         visiting[currVertex] = true;
 
-        for (int directedSuccessor : graph[currVertex]) {
-            if (visiting[directedSuccessor] || !hasAllPathsToDestination(directedSuccessor)) {
+        for (int directSuccessor : graph[currVertex]) {
+            if (visiting[directSuccessor] || !hasAllPathsToDestination(directSuccessor)) {
                 return false;
             }
         }

--- a/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
+++ b/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
@@ -1,0 +1,72 @@
+package algorithms.curated170.medium;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AllPathsfromSourceLeadToDestination {
+
+    int[][] graph;
+    boolean[] visiting;
+    int dest;
+
+    public boolean leadsToDestination(int n, int[][] edges, int source, int destination) {
+        this.dest = destination;
+        visiting = new boolean[n];
+
+        byte graphCreation = makeGraph(edges, n, source);
+        if (graphCreation == DEST_HAS_PATH) {
+            return false;
+        } else if (graphCreation == SOURCE_HAS_NO_PATH) {
+            return source == destination;
+        }
+
+        return hasAllPathsToDestination(source);
+    }
+
+    final byte GRAPH_CREATED = 1;
+    final byte DEST_HAS_PATH = 0;
+    final byte SOURCE_HAS_NO_PATH = 2;
+    
+    byte makeGraph(int[][] edges, int n, int source) {
+        int[] outDegree = new int[n];
+        for (int[] edge : edges) {
+            outDegree[edge[0]]++;
+        }
+
+        if (outDegree[dest] > 0) {
+            return DEST_HAS_PATH;
+        }
+        if (outDegree[source] == 0) {
+            return SOURCE_HAS_NO_PATH;
+        }
+
+        graph = new int[n][];
+        for (int i = 0; i < n; i++) {
+            graph[i] = new int[outDegree[i]];
+        }
+
+        int[] nextDirectSuccessorIndex = new int[n];
+        for (int[] edge : edges) {
+            graph[edge[0]][nextDirectSuccessorIndex[edge[0]]++] = edge[1];
+        }
+        return GRAPH_CREATED;
+    }
+
+    boolean hasAllPathsToDestination(int currVertex) {
+
+        if (graph[currVertex].length == 0 && currVertex != dest) {
+            return false;
+        }
+        visiting[currVertex] = true;
+
+        for (int directedSuccessor : graph[currVertex]) {
+            if (visiting[directedSuccessor] || !hasAllPathsToDestination(directedSuccessor)) {
+                return false;
+            }
+        }
+
+        visiting[currVertex] = false;
+        return true;
+    }
+
+}

--- a/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
+++ b/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
@@ -8,7 +8,10 @@ public class AllPathsfromSourceLeadToDestination {
     int[][] digraph;
     boolean[] visiting;
     int dest;
-
+    final static byte GRAPH_CREATED = 1;
+    final static byte DEST_HAS_ARC = 0;
+    final static byte SOURCE_HAS_NO_ARC = 2;
+    
     public boolean leadsToDestination(int n, int[][] arcs, int source, int destination) {
         this.dest = destination;
         visiting = new boolean[n];

--- a/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
+++ b/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class AllPathsfromSourceLeadToDestination {
 
-    int[][] graph;
+    int[][] digraph;
     boolean[] visiting;
     int dest;
 
@@ -40,26 +40,26 @@ public class AllPathsfromSourceLeadToDestination {
             return SOURCE_HAS_NO_ARC;
         }
 
-        graph = new int[n][];
+        digraph = new int[n][];
         for (int i = 0; i < n; i++) {
-            graph[i] = new int[outDegree[i]];
+            digraph[i] = new int[outDegree[i]];
         }
 
         int[] nextDirectSuccessorIndex = new int[n];
         for (int[] arc : arcs) {
-            graph[arc[0]][nextDirectSuccessorIndex[arc[0]]++] = arc[1];
+            digraph[arc[0]][nextDirectSuccessorIndex[arc[0]]++] = arc[1];
         }
         return GRAPH_CREATED;
     }
 
     boolean hasAllPathsToDestination(int currVertex) {
 
-        if (graph[currVertex].length == 0 && currVertex != dest) {
+        if (digraph[currVertex].length == 0 && currVertex != dest) {
             return false;
         }
         visiting[currVertex] = true;
 
-        for (int directSuccessor : graph[currVertex]) {
+        for (int directSuccessor : digraph[currVertex]) {
             if (visiting[directSuccessor] || !hasAllPathsToDestination(directSuccessor)) {
                 return false;
             }

--- a/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
+++ b/src/main/java/algorithms/curated170/medium/AllPathsfromSourceLeadToDestination.java
@@ -23,9 +23,7 @@ public class AllPathsfromSourceLeadToDestination {
         return hasAllPathsToDestination(source);
     }
 
-    final byte GRAPH_CREATED = 1;
-    final byte DEST_HAS_ARC = 0;
-    final byte SOURCE_HAS_NO_ARC = 2;
+ 
     
     byte makeGraph(int[][] arcs, int n, int source) {
         int[] outDegree = new int[n];


### PR DESCRIPTION
Resolves: #77 

## Algorithm:
It's good to know about the nomenclature of directed graphs here: https://en.wikipedia.org/wiki/Directed_graph
For solving this problem in anyway, we need to turn this given arcs into a directed graph.  For this, we first iterate over the arcs and count the outdegrees of the respective predecessor vertices. With this, we create a 2 dimensional array where the number of arrays is the given number `n` and the length of the each array is their respective outdegrees, otherwise we would exceed the memory (see the solution comment below). We then fill up each array with their successor vertices.

While creating the graph, if the outdegree of the destination node is not 0, this means that there is a path that is not leading to this target, it continues after the target. We should then check and return 0. If the source node has 0 arcs coming out of it, this means that the number of paths that lead to destination is 0. This means that we can't reach the target unless the source is the destination. If the source is the target, that would mean in this case that all paths from the source (0 paths) always end up in the target.

We than start a DFS from the source node. Here, we mark a node visited and then travel to its successor nodes. If we come across some visited node, this means that we have a cycle and should return false. If we end up in a node that has an outdegree of 0 but isn't destination, we return false. After traveling to and through all the successors of a node, we mark it unvisited and return true if we weren't interrupted by the aforementioned conditions. 