### PR TITLE
431. Encode N-ary Tree to Binary Tree

### DIFF
--- a/src/main/java/algorithms/curated170/hard/EncodeNaryTreeToBinaryTree.java
+++ b/src/main/java/algorithms/curated170/hard/EncodeNaryTreeToBinaryTree.java
@@ -1,0 +1,79 @@
+package algorithms.curated170.hard;
+
+import algorithms.datastructures.TreeNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EncodeNaryTreeToBinaryTree {
+
+    class Codec {
+
+        public TreeNode encode(Node root) {
+            if (root == null) {
+                return null;
+            }
+            return encodeLeftRight(root, true);
+        }
+
+        private TreeNode encodeLeftRight(Node root, boolean goLeft) {
+            TreeNode tRoot = new TreeNode(root.val);
+            TreeNode currChild = tRoot;
+
+            for (Node child : root.children) {
+                if (goLeft) {
+                    currChild.left = encodeLeftRight(child, false);
+                    currChild = currChild.left;
+                } else {
+                    currChild.right = encodeLeftRight(child, true);
+                    currChild = currChild.right;
+                }
+            }
+
+            return tRoot;
+        }
+
+        public Node decode(TreeNode root) {
+            if (root == null) {
+                return null;
+            }
+            return decodeLeftRight(root, true);
+        }
+
+        private Node decodeLeftRight(TreeNode root, boolean goLeft) {
+            Node nRoot = new Node(root.val, new ArrayList<>());
+            TreeNode currChild = root;
+
+            if (goLeft) {
+                while (currChild.left != null) {
+                    nRoot.children.add(decodeLeftRight(currChild.left, false));
+                    currChild = currChild.left;
+                }
+            } else {
+                while (currChild.right != null) {
+                    nRoot.children.add(decodeLeftRight(currChild.right, true));
+                    currChild = currChild.right;
+                }
+            }
+
+            return nRoot;
+        }
+    }
+
+    class Node {
+        public int val;
+        public List<Node> children;
+
+        public Node() {
+        }
+
+        public Node(int _val) {
+            val = _val;
+        }
+
+        public Node(int _val, List<Node> _children) {
+            val = _val;
+            children = _children;
+        }
+    }
+}


### PR DESCRIPTION
Resolves: #89 

## Algorithm:
There are few ways of implementing this. They are all inherently similar as they try to convert the parent-child relationship from the n-ary tree into a left-right relation of the the binary tree.
We can interpret all the children of the root node listed to its left like a linked list. In each of these nodes, we can interpret their children being listed towards the other direction, right, as a linked list. For their children the direction of listing becomes left. So we can just go left and then right to turn the n-ary tree into a combination of linked lists represented by the binary tree.
![image](https://user-images.githubusercontent.com/63192680/124363291-0b927800-dc43-11eb-96b4-d898e8336645.png)
