### PR TITLE
759. Employee Free Time

### DIFF
--- a/src/main/java/algorithms/curated170/hard/employeefreetime/EmployeeFreeTimePriorityQueue.java
+++ b/src/main/java/algorithms/curated170/hard/employeefreetime/EmployeeFreeTimePriorityQueue.java
@@ -1,0 +1,42 @@
+package algorithms.curated170.hard.employeefreetime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class EmployeeFreeTimePriorityQueue {
+
+    public List<Interval> employeeFreeTime(List<List<Interval>> schedule) {
+        PriorityQueue<Interval> earliestIntervals = new PriorityQueue<Interval>((a, b) -> a.start - b.start);
+        schedule.forEach(e -> earliestIntervals.addAll(e));
+
+        int end = earliestIntervals.poll().end;
+        List<Interval> commonIntervals = new ArrayList<>();
+
+        while (!earliestIntervals.isEmpty()) {
+            Interval interval = earliestIntervals.poll();
+
+            if (interval.start > end && end >= 0) {
+                commonIntervals.add(new Interval(end, interval.start));
+            }
+            if (interval.end > end) {
+                end = interval.end;
+            }
+        }
+
+        return commonIntervals;
+    }
+
+    class Interval {
+        public int start;
+        public int end;
+
+        public Interval() {
+        }
+
+        public Interval(int _start, int _end) {
+            start = _start;
+            end = _end;
+        }
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/employeefreetime/EmployeeFreeTimePriorityQueue.java
+++ b/src/main/java/algorithms/curated170/hard/employeefreetime/EmployeeFreeTimePriorityQueue.java
@@ -16,7 +16,7 @@ public class EmployeeFreeTimePriorityQueue {
         while (!earliestIntervals.isEmpty()) {
             Interval interval = earliestIntervals.poll();
 
-            if (interval.start > end && end >= 0) {
+            if (interval.start > end) {
                 commonIntervals.add(new Interval(end, interval.start));
             }
             if (interval.end > end) {

--- a/src/main/java/algorithms/curated170/hard/employeefreetime/EmployeeFreeTimeSorting.java
+++ b/src/main/java/algorithms/curated170/hard/employeefreetime/EmployeeFreeTimeSorting.java
@@ -1,0 +1,39 @@
+package algorithms.curated170.hard.employeefreetime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class EmployeeFreeTimeSorting {
+
+    public List<Interval> employeeFreeTime(List<List<Interval>> schedule) {
+        List<Interval> earliestIntervals = new ArrayList<>();
+        schedule.forEach(e -> earliestIntervals.addAll(e));
+        Collections.sort(earliestIntervals, (a, b) -> a.start - b.start);
+
+        int end = -1;
+        List<Interval> commonIntervals = new ArrayList<>();
+        for (var interval : earliestIntervals) {
+            if (interval.start > end && end >= 0) {
+                commonIntervals.add(new Interval(end, interval.start));
+            }
+            if (interval.end > end) {
+                end = interval.end;
+            }
+        }
+        return commonIntervals;
+    }
+
+    class Interval {
+        public int start;
+        public int end;
+
+        public Interval() {
+        }
+
+        public Interval(int _start, int _end) {
+            start = _start;
+            end = _end;
+        }
+    }
+}


### PR DESCRIPTION
Resolves: #91 

## Algorithm:
The point here is that any free time interval of the employees is equivalent to some time interval beginning at the end of one employee's time and ending at the other's start, where the start is later the end of the previous interval. We can then just iterate over the intervals sorted by their starting time, and add new free time intervals if the current start is later than the latest end time we have encountered. For recording the latest end time, we would simply need an integer. To iterate over the intervals in such a sorted manner, we can either directly sort it or use a priority queue. 

One can also revisit #64 in order to perhaps get a view of this problem from another point.