### PR TITLE
302. Smallest Rectangle Enclosing Black Pixels

### DIFF
--- a/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsBinarySearch.java
+++ b/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsBinarySearch.java
@@ -1,0 +1,38 @@
+package algorithms.curated170.hard.employeefreetime;
+
+public class SmallestRectangleEnclosingBlackPixelsDFS {
+
+    private char[][] image;
+
+    public int minArea(char[][] image, int x, int y) {
+        this.image = image;
+        int m = image.length, n = image[0].length;
+
+        int bottom = searchBoundary(0, x, 0, n, true, true);
+        int top = searchBoundary(x + 1, m, 0, n, false, true);
+        int left = searchBoundary(0, y, bottom, top, true, false);
+        int right = searchBoundary(y + 1, n, bottom, top, false, false);
+
+        return (right - left) * (top - bottom);
+    }
+
+    private int searchBoundary(int i, int j, int low, int high, boolean findMin, boolean isRow) {
+        while (i != j) {
+            int k = low, mid = (i + j) / 2;
+            while (k < high && isBlack(mid, k, isRow)) {
+                k++;
+            }
+            if ((k < high) == findMin) {
+                j = mid;
+            } else {
+                i = mid + 1;
+            }
+        }
+
+        return i;
+    }
+
+    private boolean isBlack(int mid, int k, boolean isRow) {
+        return ((isRow) ? image[mid][k] : image[k][mid]) == '0';
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsBinarySearch.java
+++ b/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsBinarySearch.java
@@ -1,6 +1,6 @@
 package algorithms.curated170.hard.smallestrectangleenclosingblackpixels;
 
-public class SmallestRectangleEnclosingBlackPixelsDFS {
+public class SmallestRectangleEnclosingBlackPixelsBinarySearch {
 
     private char[][] image;
 

--- a/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsBinarySearch.java
+++ b/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsBinarySearch.java
@@ -1,4 +1,4 @@
-package algorithms.curated170.hard.employeefreetime;
+package algorithms.curated170.hard.smallestrectangleenclosingblackpixels;
 
 public class SmallestRectangleEnclosingBlackPixelsDFS {
 

--- a/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsDFS.java
+++ b/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsDFS.java
@@ -1,4 +1,4 @@
-package algorithms.curated170.hard.employeefreetime;
+package algorithms.curated170.hard.smallestrectangleenclosingblackpixels;
 
 public class SmallestRectangleEnclosingBlackPixelsDFS {
     

--- a/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsDFS.java
+++ b/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsDFS.java
@@ -15,7 +15,7 @@ public class SmallestRectangleEnclosingBlackPixelsDFS {
     }
 
     private void findRectangleBoundaries(char[][] image, int x, int y) {
-        if (isOutOfBoundariesOrZero(image, x, y)) {
+        if (isOutOfBoundariesOrBlack(image, x, y)) {
             return;
         }
 
@@ -40,7 +40,7 @@ public class SmallestRectangleEnclosingBlackPixelsDFS {
         }
     }
 
-    private boolean isOutOfBoundariesOrZero(char[][] image, int x, int y) {
+    private boolean isOutOfBoundariesOrBlack(char[][] image, int x, int y) {
         return (x < 0 || y < 0 || x >= image.length || y >= image[0].length || image[x][y] == '0');
     }
 }

--- a/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsDFS.java
+++ b/src/main/java/algorithms/curated170/hard/smallestrectangleenclosingblackpixels/SmallestRectangleEnclosingBlackPixelsDFS.java
@@ -1,0 +1,46 @@
+package algorithms.curated170.hard.employeefreetime;
+
+public class SmallestRectangleEnclosingBlackPixelsDFS {
+    
+    int left, right, bottom, top;
+    int[][] directions = new int[][] { { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } };
+
+    public int minArea(char[][] image, int x, int y) {
+        left = 1000000;
+        right = 0;
+        bottom = 1000000;
+        top = 0;
+        findRectangleBoundaries(image, x, y);
+        return (right - left + 1) * (top - bottom + 1);
+    }
+
+    private void findRectangleBoundaries(char[][] image, int x, int y) {
+        if (isOutOfBoundariesOrZero(image, x, y)) {
+            return;
+        }
+
+        image[x][y] = '0';
+
+        for (int[] dir : directions) {
+            int nx = x + dir[0];
+            int ny = y + dir[1];
+            findRectangleBoundaries(image, nx, ny);
+        }
+        if (x < left) {
+            left = x;
+        }
+        if (y < bottom) {
+            bottom = y;
+        }
+        if (y > top) {
+            top = y;
+        }
+        if (x > right) {
+            right = x;
+        }
+    }
+
+    private boolean isOutOfBoundariesOrZero(char[][] image, int x, int y) {
+        return (x < 0 || y < 0 || x >= image.length || y >= image[0].length || image[x][y] == '0');
+    }
+}


### PR DESCRIPTION
Resolves: #219 
Recommended problems before this:
[200. Number of Islands](https://github.com/spiralgo/algorithms/blob/master/src/main/java/algorithms/medium/NumberOfIslands.java) : https://leetcode.com/problems/number-of-islands/
1292. Maximum Side Length of a Square with Sum Less than or Equal to Threshold: #358 
1765. Map of Highest Peak: #357 

## Algorithm:
The smallest rectangle area would correspond to a reactangle covering the left- and right-most points of the black pixels as well as the top and the bottom boundaries.
### Approach 1-Binary Search
The intuition here is that the black pixel at the bottom is located somewhere between the given x-coordinate (coordinates for 2D-arrays aren't defined properly) and 0. If we find a black pixel in any of the pixels in the row between these, that means that we must look further down to see if there is a row with a black pixel in it. Else, we look between the middle and the x. This naturally corresponds to binary-searching all the rows between these. For the upper case, we always try to look for the upper rows. For left and right, our boundaries are not just the matrix boundaries, but the already calculated bottom and top values. While searching columns, we don't look for the pixels in those areas.
### Approach 2-DFS
This approach is more straight forward but is slower, especially in cases where the majority of the image is black pixels. Since all the black pixels are connected, we can just search through the given pixel to find the boundaries. We can also mark visited nodes to `'1'` to save that they are visited.