### PR TITLE
1765. Map of Highest Peak

### DIFF
--- a/src/main/java/algorithms/medium/mapofhighestpeak/MapOfHighestPeak.java
+++ b/src/main/java/algorithms/medium/mapofhighestpeak/MapOfHighestPeak.java
@@ -3,20 +3,20 @@ package algorithms.medium.mapofhighestpeak;
 public class MapOfHighestPeak {
 
     public int[][] highestPeak(int[][] arr) {
-        int n = arr.length;
-        int m = arr[0].length;
-        int[][] heightMap = new int[n][m];
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < m; j++) {
+        int rows = arr.length;
+        int cols = arr[0].length;
+        int[][] heightMap = new int[rows][cols];
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
                 if (arr[i][j] != 1) {
                     heightMap[i][j] = Integer.MAX_VALUE;
                 }
             }
         }
-        compareToLeft(n, m, heightMap);
-        compareToRight(n, m, heightMap);
-        compareToDown(n, m, heightMap);
-        compareToUp(n, m, heightMap);
+        compareToLeft(rows, cols, heightMap);
+        compareToRight(rows, cols, heightMap);
+        compareToDown(rows, cols, heightMap);
+        compareToUp(rows, cols, heightMap);
 
         return heightMap;
     }

--- a/src/main/java/algorithms/medium/mapofhighestpeak/MapOfHighestPeak.java
+++ b/src/main/java/algorithms/medium/mapofhighestpeak/MapOfHighestPeak.java
@@ -1,0 +1,64 @@
+package algorithms.medium.mapofhighestpeak;
+
+public class MapOfHighestPeak {
+
+    public int[][] highestPeak(int[][] arr) {
+        int n = arr.length;
+        int m = arr[0].length;
+        int[][] heightMap = new int[n][m];
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (arr[i][j] != 1) {
+                    heightMap[i][j] = Integer.MAX_VALUE;
+                }
+            }
+        }
+        compareToLeft(n, m, heightMap);
+        compareToRight(n, m, heightMap);
+        compareToDown(n, m, heightMap);
+        compareToUp(n, m, heightMap);
+
+        return heightMap;
+    }
+
+    private void compareToLeft(int n, int m, int[][] heightMap) {
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m - 1; j++) {
+                if (heightMap[i][j] != Integer.MAX_VALUE) {
+                    heightMap[i][j + 1] = Math.min(heightMap[i][j + 1], heightMap[i][j] + 1);
+                }
+            }
+        }
+    }
+
+    private void compareToRight(int n, int m, int[][] heightMap) {
+        for (int i = 0; i < n; i++) {
+            for (int j = m - 1; j >= 1; j--) {
+                if (heightMap[i][j] != Integer.MAX_VALUE) {
+                    heightMap[i][j - 1] = Math.min(heightMap[i][j - 1], heightMap[i][j] + 1);
+                }
+            }
+        }
+    }
+
+    private void compareToDown(int n, int m, int[][] heightMap) {
+        for (int i = 0; i < n - 1; i++) {
+            for (int j = 0; j < m; j++) {
+                if (heightMap[i][j] != Integer.MAX_VALUE) {
+                    heightMap[i + 1][j] = Math.min(heightMap[i + 1][j], heightMap[i][j] + 1);
+                }
+            }
+        }
+    }
+
+    private void compareToUp(int n, int m, int[][] heightMap) {
+        for (int i = n - 1; i >= 1; i--) {
+            for (int j = 0; j < m; j++) {
+                if (heightMap[i][j] != Integer.MAX_VALUE) {
+                    heightMap[i - 1][j] = Math.min(heightMap[i - 1][j], heightMap[i][j] + 1);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/algorithms/medium/mapofhighestpeak/MapOfHighestPeakBFS.java
+++ b/src/main/java/algorithms/medium/mapofhighestpeak/MapOfHighestPeakBFS.java
@@ -1,0 +1,68 @@
+package algorithms.medium.mapofhighestpeak;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class MapOfHighestPeakBFS {
+    int[][] DIRECTIONS = { { 1, 0 }, { 0, 1 }, { -1, 0 }, { 0, -1 } };
+    int[][] heightMap;
+    int rows, cols;
+
+    public int[][] highestPeak(int[][] isWater) {
+        rows = isWater.length;
+        cols = isWater[0].length;
+        heightMap = new int[rows][cols];
+
+        Deque<int[]> levelTiles = createInitialLevel(isWater);
+
+        traverseHeightLevels(levelTiles);
+
+        return heightMap;
+    }
+
+    private Deque<int[]> createInitialLevel(int[][] isWater) {
+        Deque<int[]> levelTiles = new ArrayDeque<>();
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                if (isWater[i][j] == 1) {
+                    levelTiles.offer(new int[] { i, j });
+                } else {
+                    heightMap[i][j] = -1;
+                }
+            }
+        }
+        return levelTiles;
+    }
+
+    private void traverseHeightLevels(Deque<int[]> levelTiles) {
+        int curLevel = 1;
+        while (!levelTiles.isEmpty()) {
+            int levelSize = levelTiles.size();
+            for (int i = 0; i < levelSize; i++) {
+                int[] tile = levelTiles.poll();
+                int x = tile[0];
+                int y = tile[1];
+                setAdjacentHeights(levelTiles, x, y, curLevel);
+            }
+            curLevel++;
+        }
+
+    }
+
+    private void setAdjacentHeights(Deque<int[]> levelTiles, int x, int y, int curLevel) {
+        for (int[] dir : DIRECTIONS) {
+            int nx = x + dir[0];
+            int ny = y + dir[1];
+            if (isOutOfMapOrAssigned(nx, ny)) {
+                continue;
+            }
+            heightMap[nx][ny] = curLevel;
+            levelTiles.offer(new int[] { nx, ny });
+        }
+    }
+
+    private boolean isOutOfMapOrAssigned(int nx, int ny) {
+        return (nx < 0 || nx >= rows || ny < 0 || ny >= cols || heightMap[nx][ny] != -1);
+    }
+
+}


### PR DESCRIPTION
Problem: https://leetcode.com/problems/map-of-highest-peak/

### Appraoch 1-BFS
In order to solve this problem, we need to think of these heights as minimum distances from the closest water tiles. The most intuitive way of doing this is starting a level-by-level, i.e. breadth-first search from the given sea tiles. Initially, we also set the non-sea tiles to -1 to represent that they are not assigned yet. We only assign a tile a height if its height is unassigned so that we don't reassign greater heights.
### Appraoch 2-Cardinal Comparison:
In theory, the BFS approach should be fast but the data structures required for it are always slow in implementation. We can solve this problem by only using arrays. Before understanding how this is done, one can refer to #295. If we given just a line of tiles, the closest water tile would have been either the closest left one or the closest right. Hence, for every single individual row in the map, we can calculate these distances. Since the map is naturally 2D, we can also apply this strategy for every single column. In each column, the distance from water can just be the vertical distance to some other tile plus the height of that tile, so we calculate the Manhattan Distance from corresponding water tiles indirectly. We always pick the minimum and eventually set up the complete height map.