### PR TITLE
1292. Maximum Side Length of a Square with Sum Less than or Equal to Threshold

### DIFF
--- a/src/main/java/algorithms/MaximumLineLengthWithSumLessThanOrEqualToThreshold.java
+++ b/src/main/java/algorithms/MaximumLineLengthWithSumLessThanOrEqualToThreshold.java
@@ -1,0 +1,24 @@
+package algorithms;
+
+public class MaximumLineLengthWithSumLessThanOrEqualToThreshold {
+  
+  public int maxLength(int[] array, int threshold) {
+    int len = 1;
+    int[] sums = new int[array.length + 1];
+    for (int i = 1; i <= array.length; i++) {
+      sums[i] += sums[i-1] + array[i - 1];
+      if (i >= len && sums[i] - sums[i - len] <= threshold) {
+        len++;
+      }
+    }
+    return len - 1;
+  }
+
+  public static void main(String[] args) {
+    int[] array = { 1, 1, 1, 3, 5 };
+    // Prefix sum: [0, 1, 2, 3, 6, 11]
+    var solution = new MaximumLineLengthWithSumLessThanOrEqualToThreshold();
+    System.out.println(solution.maxLength(array, 15)); // 5
+    System.out.println(solution.maxLength(array, 3)); // 3
+  }
+}

--- a/src/main/java/algorithms/MaximumLineLengthWithSumLessThanOrEqualToThreshold.java
+++ b/src/main/java/algorithms/MaximumLineLengthWithSumLessThanOrEqualToThreshold.java
@@ -7,7 +7,7 @@ public class MaximumLineLengthWithSumLessThanOrEqualToThreshold {
     int[] sums = new int[array.length + 1];
     for (int i = 1; i <= array.length; i++) {
       sums[i] += sums[i-1] + array[i - 1];
-      if (i >= len && sums[i] - sums[i - len] <= threshold) {
+      if (i >= len && (sums[i] - sums[i - len]) <= threshold) {
         len++;
       }
     }

--- a/src/main/java/algorithms/medium/MaximumSideLengthOfASquareWithSumLessThanOrEqualToThreshold.java
+++ b/src/main/java/algorithms/medium/MaximumSideLengthOfASquareWithSumLessThanOrEqualToThreshold.java
@@ -21,7 +21,7 @@ public class MaximumSideLengthOfASquareWithSumLessThanOrEqualToThreshold {
     }
 
     private int getCurrentSquareSum(int[][] sum, int i, int j, int len) {
-        return sum[i][j] - sum[i - len][j] - sum[i][j - len] + sum[i - len][j - len];
+        return (sum[i][j] - sum[i - len][j] - sum[i][j - len] + sum[i - len][j - len]);
     }
 
 }

--- a/src/main/java/algorithms/medium/MaximumSideLengthOfASquareWithSumLessThanOrEqualToThreshold.java
+++ b/src/main/java/algorithms/medium/MaximumSideLengthOfASquareWithSumLessThanOrEqualToThreshold.java
@@ -1,0 +1,27 @@
+package algorithms.medium;
+
+public class MaximumSideLengthOfASquareWithSumLessThanOrEqualToThreshold {
+    
+    public int maxSideLength(int[][] mat, int threshold) {
+        int rows = mat.length, cols = mat[0].length;
+        int len = 1;
+        int[][] sum = new int[rows + 1][cols + 1];
+        for (int i = 1; i <= rows; i++) {
+            int rowSum = 0;
+            for (int j = 1; j <= cols; j++) {
+                rowSum += mat[i - 1][j - 1];
+                sum[i][j] = rowSum + sum[i - 1][j];
+                if (i >= len && j >= len && getCurrentSquareSum(sum, i, j, len) <= threshold) {
+                    len++;
+                }
+            }
+
+        }
+        return len - 1;
+    }
+
+    private int getCurrentSquareSum(int[][] sum, int i, int j, int len) {
+        return sum[i][j] - sum[i - len][j] - sum[i][j - len] + sum[i - len][j - len];
+    }
+
+}


### PR DESCRIPTION
Problem:
https://leetcode.com/problems/maximum-side-length-of-a-square-with-sum-less-than-or-equal-to-threshold/

## Algorithm:
Here, it's easier to think about the 1D first (I've also added the algorithm for in the code). The problem there would be finding the longest line, sum of which is less than or equal to the threshold. We can begin by assuming that the longest length `len` is 0. When looping through the array, if we come across a line that is longer than the `len`, then we should update `len`. Now, if `len` becomes 5, that means that we don't need to check lines of `length < 5`. At any index, if the sum of the elements up to the `index` minus the sum of the elements up to `index-len-1` is less than or equal to the threshold, that means that `len` has to be incremented. So, we use prefix sums to find the solution to this problem.

The same can be done with matrices. At each entry i-j, the sum of the square of side length `len+1` can be calculated with prefix matrix sums. The sum of such squares are equal to:
`sum[i][j] - sum[i - len][j] - sum[i][j - len] + sum[i - len][j - len]`
To visualize: 
![image](https://user-images.githubusercontent.com/63192680/124439470-215a8700-dd82-11eb-9769-00a48e5ec9db.png)
The square sum for the green square on the bottom right is equal to the matrix sum at that point minus the matrix the sum of the excluded rows minus the matrix sum of the sxcluded columns + the double-subtracted intersection of the two.
