### PR TITLE
465. Optimal Account Balancing

### DIFF
--- a/src/main/java/algorithms/curated170/hard/OptimalAccountBalancing.java
+++ b/src/main/java/algorithms/curated170/hard/OptimalAccountBalancing.java
@@ -1,86 +1,99 @@
 package algorithms.curated170.hard;
 
-public class OptimalAccountBalancing {
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
+public class OptimalAccountBalancing {
+    
     public int minTransfers(int[][] transactions) {
-        if (transactions == null || transactions.length == 0 || transactions[0].length == 0) {
-            return 0;
-        }
-        
         int n = transactions.length;
         if (n == 1) {
             return 1;
         }
-        
+
         int[] debt = buildDebtArray(transactions);
-        
-        int m = debt.length;
+
         Arrays.sort(debt);
-        int zeroNum = 0;
-        int res = 0;
+        
+        return cancelOppositeTransactions(debt);
+        
+    }
+    private int cancelOppositeTransactions(int[] debt)
+    {
+        int m = debt.length;
+        int cancelledCount = 0;
+        int transactions = 0;
         boolean[] isZero = new boolean[m];
+
         for (int i = 0, j = m - 1; i < j;) {
             int cur = debt[i] + debt[j];
+
             if (cur == 0) {
                 isZero[i++] = true;
-                isZero[j--] = true;                
-                res++;
-                zeroNum += 2;
+                isZero[j--] = true;
+                transactions++;
+                cancelledCount += 2;
             } else if (cur < 0) {
                 i++;
             } else {
                 j--;
             }
         }
-        int[] finalDebt = new int[m - zeroNum];
+
+        int[] finalDebt = new int[m - cancelledCount];
         for (int i = 0, j = 0; i < m; i++) {
             if (!isZero[i]) {
                 finalDebt[j++] = debt[i];
             }
         }
-        
-        return res + backtrack(0, finalDebt);
+
+        return transactions + tryHandlingRemainingTransactions(0, finalDebt);
     }
-    
+
     private int[] buildDebtArray(int[][] transactions) {
-        Map<Integer, Integer> map = new HashMap<>();
-        for (int[] curTran: transactions) {
-            int from = curTran[0];
-            int to = curTran[1];
-            int amount = curTran[2];
-            map.put(from, map.getOrDefault(from, 0) - amount);
-            map.put(to, map.getOrDefault(to, 0) + amount);
+        Map<Integer, Integer> balances = new HashMap<>();
+        
+        for (int[] transaction : transactions) {
+            int from = transaction[0];
+            int to = transaction[1];
+            int amount = transaction[2];
+
+            balances.merge(from, -amount, Integer::sum);
+            balances.merge(to, +amount, Integer::sum);
         }
-        int[] res = new int[map.size()];
+
+        int[] debts = new int[balances.size()];
         int i = 0;
-        for (int x: map.values()) {
+
+        for (int x : balances.values()) {
             if (x != 0) {
-                res[i++] = x;
+                debts[i++] = x;
             }
         }
-        return Arrays.copyOf(res, i);
+
+        return Arrays.copyOf(debts, i);
     }
-    
-    private int backtrack(int curId, int[] debt) {
+
+    private int tryHandlingRemainingTransactions(int curId, int[] debt) {
         while (curId < debt.length && debt[curId] == 0) {
             curId++;
         }
-        // Base case.
+
         if (curId == debt.length) {
-            return 0;   
-        }            
-        // Recursive case.
-        int min = Integer.MAX_VALUE;
+            return 0;
+        }
+
+        int minTransactions = Integer.MAX_VALUE;
+
         for (int i = curId + 1; i < debt.length; i++) {
             if (debt[i] * debt[curId] < 0) {
                 debt[i] += debt[curId];
-                min = Math.min(min, 1 + backtrack(curId + 1, debt));
+                minTransactions = Math.min(minTransactions, 1 + tryHandlingRemainingTransactions(curId + 1, debt));
                 debt[i] -= debt[curId];
             }
         }
-        
-        return min;
+
+        return minTransactions;
     }
-
-
 }

--- a/src/main/java/algorithms/curated170/hard/OptimalAccountBalancing.java
+++ b/src/main/java/algorithms/curated170/hard/OptimalAccountBalancing.java
@@ -1,0 +1,86 @@
+package algorithms.curated170.hard;
+
+public class OptimalAccountBalancing {
+
+    public int minTransfers(int[][] transactions) {
+        if (transactions == null || transactions.length == 0 || transactions[0].length == 0) {
+            return 0;
+        }
+        
+        int n = transactions.length;
+        if (n == 1) {
+            return 1;
+        }
+        
+        int[] debt = buildDebtArray(transactions);
+        
+        int m = debt.length;
+        Arrays.sort(debt);
+        int zeroNum = 0;
+        int res = 0;
+        boolean[] isZero = new boolean[m];
+        for (int i = 0, j = m - 1; i < j;) {
+            int cur = debt[i] + debt[j];
+            if (cur == 0) {
+                isZero[i++] = true;
+                isZero[j--] = true;                
+                res++;
+                zeroNum += 2;
+            } else if (cur < 0) {
+                i++;
+            } else {
+                j--;
+            }
+        }
+        int[] finalDebt = new int[m - zeroNum];
+        for (int i = 0, j = 0; i < m; i++) {
+            if (!isZero[i]) {
+                finalDebt[j++] = debt[i];
+            }
+        }
+        
+        return res + backtrack(0, finalDebt);
+    }
+    
+    private int[] buildDebtArray(int[][] transactions) {
+        Map<Integer, Integer> map = new HashMap<>();
+        for (int[] curTran: transactions) {
+            int from = curTran[0];
+            int to = curTran[1];
+            int amount = curTran[2];
+            map.put(from, map.getOrDefault(from, 0) - amount);
+            map.put(to, map.getOrDefault(to, 0) + amount);
+        }
+        int[] res = new int[map.size()];
+        int i = 0;
+        for (int x: map.values()) {
+            if (x != 0) {
+                res[i++] = x;
+            }
+        }
+        return Arrays.copyOf(res, i);
+    }
+    
+    private int backtrack(int curId, int[] debt) {
+        while (curId < debt.length && debt[curId] == 0) {
+            curId++;
+        }
+        // Base case.
+        if (curId == debt.length) {
+            return 0;   
+        }            
+        // Recursive case.
+        int min = Integer.MAX_VALUE;
+        for (int i = curId + 1; i < debt.length; i++) {
+            if (debt[i] * debt[curId] < 0) {
+                debt[i] += debt[curId];
+                min = Math.min(min, 1 + backtrack(curId + 1, debt));
+                debt[i] -= debt[curId];
+            }
+        }
+        
+        return min;
+    }
+
+
+}


### PR DESCRIPTION
Resolves: #224 

## Algorithm:
If someone gives me $10 and I give that person $10 back, it would mean that there are 0 transactions needed. 
If I give that person only $8 back, the situation is equivalent to me getting only $2 from the person.
If someone comes and gives the person in $2 deficit that money, the situation is now equivalent to the new person giving me $2. So, we calculate how much each person is in deficit/surplus. If their accounts are balanced with $0 change, we don't include them in the debts list, as no transactions will be done with them. 
Some debts will directly cancel each other. In the state above, the debts would look like this: `[-2, 2]` (second person is balanced). These values would directly cancel each other, so we don't need extra computation for it. But what if the debts look like this: `[-4, -4, 2, 6]`. We can try paying the first person with the 3. Then we have [0, -4, -2, 6]. We can pay the second with the last to get [0, 0, -2, 2]. The last two can cancel each other out and we would be left with 3 transactions. This is in fact the solution here, but it may not be in other situations. So, we might have to try all opposite-signed balances. For this, to cancel out the side-effects of the previous trial, we can use simple backtracking.