### PR TITLE
123. Best Time to Buy and Sell Stock III & 188. Best Time to Buy and Sell Stock IV

### DIFF
--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
@@ -1,0 +1,60 @@
+package algorithms.hard;
+
+public class BestTimeToBuyAndSellStockBinarySearch {
+
+	final int TOO_MANY_TRANSACTIONS = -1;
+	public int maxProfit(int k, int[] prices) {
+		int len = prices.length;
+		if (k >= (len / 2)) {
+			return maxProfitNoTransactionLimit(prices);
+		}
+		int lo = 0, hi = 1000;
+		int totalProfit = 0;
+		while (lo < hi) {
+			int mid = (lo + hi) / 2;
+			int profit = calc(mid, prices, k);
+			if (profit != TOO_MANY_TRANSACTIONS) {
+				totalProfit = profit + mid * k;
+				hi = mid;
+			} else {
+				lo = mid + 1;
+			}
+		}
+		return totalProfit;
+	}
+
+	private int calc(int sellLimit, int[] prices, int k) {
+		int holdIncome = -prices[0], holdCount = 0;
+		int sellsProfit = 0, sellsCount = 0;
+
+		for (int i = 1; i < prices.length; i++) {
+			int price = prices[i];
+			if (price + holdIncome - sellLimit > sellsProfit) {
+				sellsProfit = price + holdIncome - sellLimit;
+				sellsCount = holdCount + 1;
+			}
+			if (sellsProfit - price > holdIncome) {
+				holdIncome = sellsProfit - price;
+				holdCount = sellsCount;
+			}
+		}
+		return sellsCount > k ? TOO_MANY_TRANSACTIONS : sellsProfit;
+	}
+
+	private int maxProfitNoTransactionLimit(int[] prices) {
+		int totalProfit = 0;
+		for (int i = 1; i < prices.length; i++) {
+			int profitIncrement = prices[i] - prices[i - 1];
+			if (profitIncrement > 0) {
+				totalProfit += profitIncrement;
+			}
+		}
+		return totalProfit;
+	}
+
+	public static void main(String[] args) {
+		int[] prices = { 3, 2, 6, 5, 0, 3, 1, 4, 9 };
+		var solution = new BestTimeToBuyAndSellStockBinarySearch();
+		System.out.println(solution.maxProfit(3, prices)); // 2-6, 0-3, 1-9 => 15
+	}
+}

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
@@ -12,7 +12,7 @@ public class BestTimeToBuyAndSellStockBinarySearch {
 		int totalProfit = 0;
 		while (lo < hi) {
 			int mid = (lo + hi) / 2;
-			int profit = calc(mid, prices, k);
+			int profit = countProfitWithSellBoundary(mid, prices, k);
 			if (profit != TOO_MANY_TRANSACTIONS) {
 				totalProfit = profit + mid * k;
 				hi = mid;
@@ -23,14 +23,14 @@ public class BestTimeToBuyAndSellStockBinarySearch {
 		return totalProfit;
 	}
 
-	private int calc(int sellLimit, int[] prices, int k) {
+	private int countProfitWithSellBoundary(int sellLimit, int[] prices, int k) {
 		int holdIncome = -prices[0], holdCount = 0;
 		int sellsProfit = 0, sellsCount = 0;
 
 		for (int i = 1; i < prices.length; i++) {
 			int price = prices[i];
-			if (price + holdIncome - sellLimit > sellsProfit) {
-				sellsProfit = price + holdIncome - sellLimit;
+			if (holdIncome + price - sellLimit > sellsProfit) {
+				sellsProfit = holdIncome + price - sellLimit;
 				sellsCount = holdCount + 1;
 			}
 			if (sellsProfit - price > holdIncome) {

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
@@ -4,10 +4,10 @@ public class BestTimeToBuyAndSellStockBinarySearch {
 
 	final int TOO_MANY_TRANSACTIONS = -1;
 	public int maxProfit(int k, int[] prices) {
-		int len = prices.length;
-		if (k >= (len / 2)) {
+		if (k >= (prices.length / 2)) {
 			return maxProfitNoTransactionLimit(prices);
 		}
+
 		int lo = 0, hi = 1000;
 		int totalProfit = 0;
 		while (lo < hi) {

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockBinarySearch.java
@@ -11,26 +11,26 @@ public class BestTimeToBuyAndSellStockBinarySearch {
 		int lo = 0, hi = 1000;
 		int totalProfit = 0;
 		while (lo < hi) {
-			int mid = (lo + hi) / 2;
-			int profit = countProfitWithSellBoundary(mid, prices, k);
+			int minSellPrice = (lo + hi) / 2;
+			int profit = countProfitWithSellBoundary(minSellPrice, prices, k);
 			if (profit != TOO_MANY_TRANSACTIONS) {
-				totalProfit = profit + mid * k;
-				hi = mid;
+				totalProfit = profit + minSellPrice * k;
+				hi = minSellPrice;
 			} else {
-				lo = mid + 1;
+				lo = minSellPrice + 1;
 			}
 		}
 		return totalProfit;
 	}
 
-	private int countProfitWithSellBoundary(int sellLimit, int[] prices, int k) {
+	private int countProfitWithSellBoundary(int minSellPrice, int[] prices, int k) {
 		int holdIncome = -prices[0], holdCount = 0;
 		int sellsProfit = 0, sellsCount = 0;
 
 		for (int i = 1; i < prices.length; i++) {
 			int price = prices[i];
-			if (holdIncome + price - sellLimit > sellsProfit) {
-				sellsProfit = holdIncome + price - sellLimit;
+			if (holdIncome + price - minSellPrice > sellsProfit) {
+				sellsProfit = holdIncome + price - minSellPrice;
 				sellsCount = holdCount + 1;
 			}
 			if (sellsProfit - price > holdIncome) {

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIII.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIII.java
@@ -1,0 +1,30 @@
+package algorithms.hard;
+
+public class BestTimeToBuyAndSellStockIII {
+
+    public int maxProfit(int[] prices) {
+		int currBuy1 = Integer.MAX_VALUE, maxProfit1 = 0;
+		int currBuy2 = Integer.MAX_VALUE, maxProfit2 = 0;
+        for (int p : prices) {
+			if (p < currBuy1) {
+				currBuy1 = p;
+			} else {
+				maxProfit1 = Math.max(maxProfit1, p - currBuy1);
+			}
+            
+            int secondBuyCost = p - maxProfit1;
+            if (secondBuyCost < currBuy2) {
+				currBuy2 = secondBuyCost;
+			} else {
+				maxProfit2 = Math.max(maxProfit2, p - currBuy2);
+			}
+
+		}
+		return maxProfit2;
+	}
+
+    public static void main(String[] args) {
+        int[] nums = {7,2,5,10,8, 12, 3, 4, 9, 5, 7, 4};
+        var solution = new BestTimeToBuyAndSellStockIII();
+    }
+}

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIV.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIV.java
@@ -1,0 +1,42 @@
+package algorithms.hard;
+
+public class BestTimeToBuyAndSellStockIV {
+
+	public int maxProfit(int k, int[] prices) {
+		int len = prices.length;
+		if (k >= (len / 2))
+			return maxProfitNoTransactionLimit(prices);
+
+		int[] currBest = new int[len];
+		int[] prevBest = new int[len];
+
+		for (int i = 1; i <= k; i++) {
+			int holdStateIncome = -prices[0];
+			for (int j = 1; j < len; j++) {
+				currBest[j] = Math.max(currBest[j - 1], prices[j] + holdStateIncome);
+				holdStateIncome = Math.max(holdStateIncome, prevBest[j - 1] - prices[j]);
+			}
+			prevBest = currBest;
+			currBest = new int[len];
+		}
+		
+		return prevBest[len - 1];
+	}
+
+	public int maxProfitNoTransactionLimit(int[] prices) {
+		int totalProfit = 0;
+		for (int i = 1; i < prices.length; i++) {
+			int profitIncrement = prices[i] - prices[i - 1];
+			if (profitIncrement > 0) {
+				totalProfit += profitIncrement;
+			}
+		}
+		return totalProfit;
+	}
+
+	public static void main(String[] args) {
+		int[] prices = { 3, 2, 6, 5, 0, 3, 1, 4, 9 };
+		var solution = new BestTimeToBuyAndSellStockIV();
+		System.out.println(solution.maxProfit(3, prices)); // 2-6, 0-3, 1-9 => 15
+	}
+}

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIV.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIV.java
@@ -4,8 +4,9 @@ public class BestTimeToBuyAndSellStockIV {
 
 	public int maxProfit(int k, int[] prices) {
 		int len = prices.length;
-		if (k >= (len / 2))
+		if (k >= (len / 2)) {
 			return maxProfitNoTransactionLimit(prices);
+		}
 
 		int[] currBest = new int[len];
 		int[] prevBest = new int[len];
@@ -19,11 +20,11 @@ public class BestTimeToBuyAndSellStockIV {
 			prevBest = currBest;
 			currBest = new int[len];
 		}
-		
+
 		return prevBest[len - 1];
 	}
 
-	public int maxProfitNoTransactionLimit(int[] prices) {
+	private int maxProfitNoTransactionLimit(int[] prices) {
 		int totalProfit = 0;
 		for (int i = 1; i < prices.length; i++) {
 			int profitIncrement = prices[i] - prices[i - 1];

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIV.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIV.java
@@ -3,25 +3,25 @@ package algorithms.hard;
 public class BestTimeToBuyAndSellStockIV {
 
 	public int maxProfit(int k, int[] prices) {
-		int len = prices.length;
-		if (k >= (len / 2)) {
+		final int LEN = prices.length;
+		if (k >= (LEN / 2)) {
 			return maxProfitNoTransactionLimit(prices);
 		}
 
-		int[] currBest = new int[len];
-		int[] prevBest = new int[len];
+		int[] currBest = new int[LEN];
+		int[] prevBest = new int[LEN];
 
 		for (int i = 1; i <= k; i++) {
 			int holdStateIncome = -prices[0];
-			for (int j = 1; j < len; j++) {
+			for (int j = 1; j < LEN; j++) {
 				currBest[j] = Math.max(currBest[j - 1], prices[j] + holdStateIncome);
 				holdStateIncome = Math.max(holdStateIncome, prevBest[j - 1] - prices[j]);
 			}
 			prevBest = currBest;
-			currBest = new int[len];
+			currBest = new int[LEN];
 		}
 
-		return prevBest[len - 1];
+		return prevBest[LEN - 1];
 	}
 
 	private int maxProfitNoTransactionLimit(int[] prices) {

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIVPriorityQueue.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIVPriorityQueue.java
@@ -1,7 +1,5 @@
 package algorithms.hard;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Stack;
 
@@ -9,8 +7,9 @@ public class BestTimeToBuyAndSellStockIVPriorityQueue {
 
 	public int maxProfit(int k, int[] prices) {
 		final int LEN = prices.length;
-		if (k < 1 || prices == null || LEN == 0)
-			return 0;
+		if (k >= (LEN / 2)) {
+			return maxProfitNoTransactionLimit(prices);
+		}
 
 		PriorityQueue<Integer> profits = new PriorityQueue<>((a, b) -> b - a);
 		Stack<Integer> starts = new Stack<>();
@@ -57,6 +56,17 @@ public class BestTimeToBuyAndSellStockIVPriorityQueue {
 		}
 		starts.push(s);
 		ends.push(e);
+	}
+
+	private int maxProfitNoTransactionLimit(int[] prices) {
+		int totalProfit = 0;
+		for (int i = 1; i < prices.length; i++) {
+			int profitIncrement = prices[i] - prices[i - 1];
+			if (profitIncrement > 0) {
+				totalProfit += profitIncrement;
+			}
+		}
+		return totalProfit;
 	}
 
 	public static void main(String[] args) {

--- a/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIVPriorityQueue.java
+++ b/src/main/java/algorithms/hard/BestTimeToBuyAndSellStockIVPriorityQueue.java
@@ -1,0 +1,76 @@
+package algorithms.hard;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Stack;
+
+public class BestTimeToBuyAndSellStockIVPriorityQueue {
+
+	public int maxProfit(int k, int[] prices) {
+		final int LEN = prices.length;
+		if (k < 1 || prices == null || LEN == 0)
+			return 0;
+
+		PriorityQueue<Integer> profits = new PriorityQueue<>((a, b) -> b - a);
+		Stack<Integer> starts = new Stack<>();
+		Stack<Integer> ends = new Stack<>();
+		int s, e = 0;
+
+		while (e < LEN) {
+			s = e;
+			while (s + 1 < LEN && prices[s] >= prices[s + 1]) {
+				s++;
+			}
+
+			e = s + 1;
+			while (e + 1 < LEN && prices[e] <= prices[e + 1]) {
+				e++;
+			}
+			
+			if (s < e && s < LEN && e < LEN) {
+				findMaxRanges(prices, profits, starts, ends, s, e);
+			}
+		}
+
+		while (!starts.isEmpty()) {
+			profits.add(prices[ends.pop()] - prices[starts.pop()]);
+		}
+
+		int totalProfit = 0;
+		for (int t = 0; t < k && !profits.isEmpty(); t++) {
+			totalProfit += profits.poll();
+		}
+
+		return totalProfit;
+	}
+
+	private void findMaxRanges(int[] prices, PriorityQueue<Integer> profits, Stack<Integer> starts, Stack<Integer> ends,
+			int s, int e) {
+		while (!starts.isEmpty() && prices[s] < prices[starts.peek()]) {
+			profits.add(prices[ends.pop()] - prices[starts.pop()]);
+		}
+
+		while (!starts.isEmpty() && prices[e] >= prices[ends.peek()]) {
+			profits.add(prices[ends.pop()] - prices[s]);
+			s = starts.pop();
+		}
+		starts.push(s);
+		ends.push(e);
+	}
+
+	public static void main(String[] args) {
+		int[] prices = { 3, 2, 6, 5, 0, 3, 1, 4, 9 };
+		var solution = new BestTimeToBuyAndSellStockIVPriorityQueue();
+		System.out.println(solution.maxProfit(3, prices)); // 2-6, 0-3, 1-9 => 15
+
+		prices = new int[] { 2, 3, 1, 4, 12 };
+		System.out.println(solution.maxProfit(1, prices)); // 1-12 => 11
+
+		prices = new int[] { 1, 5, 7, 4, 12 };
+		System.out.println(solution.maxProfit(1, prices)); // 1-12 => 11
+
+		prices = new int[] { 1, 5, 4, 7, 5, 27 };
+		System.out.println(solution.maxProfit(1, prices)); // 1-27 => 26
+	}
+}


### PR DESCRIPTION
Like their prequels, these problems are dynamic programming problems.

## 123. Best Time to Buy and Sell Stock III
Problem: https://leetcode.com/problems/best-time-to-buy-and-sell-stock-iii/

This one is pretty similar to #297. When we are buying for the second time, we are removing from the profit earned from the first transaction. So, instead of subtracting the price from 0, we subtract it from the first transaction profit and then add on to it when we are selling. So, we just need two more variables.

## 188. Best Time to Buy and Sell Stock IV
Problem: https://leetcode.com/problems/best-time-to-buy-and-sell-stock-iv/

Here, there are 3 approaches. The dynamic programming one sounds more familiar, so I will explain it first:
## 1. Dynamic Programming
When we are deciding for the i-th transaction at j-th price, it's pretty easy to derive a recursive formula:
`dp[i][j] = max(dp[i-1][j], dp[i-1][j-1] - prices[h] + prices[j])`, where `h<j`.
This is semantically equivalent  to saying "The maximum profit for some transaction at some index is equivalent to the maximum of either not making any new transactions at that index or the maximum profit at the previous transaction in some previous index added with profit of some new transaction where we sell at some index.". "Some previous index" can be decided linearly by comparing the maximum for the expression `dp[i-1][j-1] - prices[h]` for all indices up to `j`.

## 2. Valley-Peak Merging

![image](https://user-images.githubusercontent.com/63192680/125409469-994d3080-e3c4-11eb-8aad-6d310f5b2d83.png)
When we look at the graph of some prices, we see local minimum and maximums. 
When the given number k is less than the number of valley-peak pairs, we have to exclude some of those. In the graph above, if we were only allowed a single transaction, we would have chose the fist price to buy and the last to sell, merging the valley and the peak, excluding those in-between. 
Think of some prices like this: [1,7,5,12], where k = 1
The best choice here is 1|12 yielding 11 profit. If we did two transactions with 1|7 and 5|12, we would have earned 13, exactly 7-5 more than the previous one. The reason is, when k is 2, profit is p2 - v2 + p1 - v1. When k = 1, profit = p2 - v1. That is how that increment comes. So, if needed, we pick the largest range value. We include the second value by including the profit from p1 - v2. This also holds for 3 or more transactions, when their profits overlap. p3 - v3 + p2 - v2 + p1 - v1 => pick p3 - v1, pick p2 - v3, pick p1 - v2 etc. We can put all the profits into a priority queue and just poll them. This algorithm should be faster in theory with linearithmic time in comparison to DP's pseudo-quadratic complexity, but it's slower in implementation.

## 3. Binary Searching
The procedure used for solving #369 and #368 can be used for this problem too.
We can actually sort out at which prices we sell by placing a lower boundary for it. We then count how many transactions are done with this lower bound. If the number exceeds k, we need to increase the lower bound, else, we need to decrease to earn more profit. This binary searching approach is the fastest. 