### PR TITLE
Stack, Array Deque and Array List Structures

### DIFF
--- a/src/main/java/algorithms/datastructures/ArrayListS.java
+++ b/src/main/java/algorithms/datastructures/ArrayListS.java
@@ -1,0 +1,45 @@
+package algorithms.datastructures;
+
+import algorithms.datastructures.DequeS;
+
+public class ArrayListS<T> extends DequeS<T> {
+
+    public T get(int idx) {
+        return (T) data[getIndex(idx, true)];
+    }
+
+    public ArrayListS set(int idx, T val) {
+        data[getIndex(idx, true)] = val;
+        return this;
+    }
+
+    public T getAt(int idx) {
+        return (T) data[getIndex(idx, false)];
+    }
+
+    public ArrayListS setAt(int idx, T val) {
+        data[getIndex(idx, false)] = val;
+        return this;
+    }
+
+    private int getIndex(int idx, boolean checkSize) {
+        if (checkSize && idx >= getSize()) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (qIdx <= sIdx || idx < (data.length - qIdx)) {
+            return qIdx + idx;
+        } else {
+            return idx - (data.length - qIdx);
+        }
+    }
+
+    public static void main(String[] args) {
+        var aList = new ArrayListS<Integer>();
+        System.out.println(aList + " with size: " + aList.getSize());
+        aList.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
+        System.out.println(aList);
+        System.out.println(aList.get(1));
+        System.out.println(aList.get(7));
+        System.out.println(aList.set(0, 9).set(3, 99));
+    }
+}

--- a/src/main/java/algorithms/datastructures/DequeS.java
+++ b/src/main/java/algorithms/datastructures/DequeS.java
@@ -1,0 +1,182 @@
+package algorithms.datastructures;
+
+import java.util.EmptyStackException;
+import java.util.LinkedList;
+
+public class DequeS<T> {
+
+    private Object[] data;
+    private static final int EXPANSION_SIZE = 2;
+    private int sIdx = -1;
+    private int qIdx = 8;
+
+    public DequeS() {
+        data = new Object[8];
+    }
+
+    public DequeS(int initialCapacity) {
+        data = new Object[initialCapacity];
+        qIdx = initialCapacity;
+    }
+
+    public DequeS<T> push(T val) {
+        if (sIdx == qIdx - 1) {
+            expandSize();
+        }
+        data[++sIdx % data.length] = val;
+        if (sIdx == 0 && qIdx == data.length) {
+            qIdx = 0;
+        }
+        return this;
+    }
+
+    public DequeS<T> offer(T val) {
+        if (qIdx == sIdx + 1) {
+            expandSize();
+        }
+        qIdx = (((qIdx - 1) % data.length) + data.length) % data.length;
+        data[((qIdx) + data.length) % data.length] = val;
+        if (qIdx == data.length - 1 && sIdx == -1) {
+            sIdx = data.length - 1;
+        }
+        return this;
+    }
+
+    private void expandSize() {
+        Object[] newData = new Object[data.length * EXPANSION_SIZE];
+
+        for (int i = 0; i <= sIdx; i++) {
+            newData[i] = data[i];
+        }
+        for (int i = 1; i <= data.length - qIdx; i++) {
+            newData[newData.length - i] = data[data.length - i];
+        }
+        qIdx = newData.length - qIdx;
+
+        data = newData;
+    }
+
+    public T pop() {
+        if (sIdx < 0) {
+            if (qIdx == 0) {
+                qIdx = data.length;
+            } else if (qIdx < data.length) {
+                sIdx = data.length - 1;
+            } else {
+                return null;
+            }
+        }
+
+        T val = (T) data[sIdx];
+        data[sIdx--] = null;
+        if (qIdx == sIdx + 1) {
+            sIdx = -1;
+            qIdx = data.length;
+        }
+        return val;
+    }
+    public T[] popN(int n)
+    {
+        Object[] popped = new Object[n];
+        for(int i = 0; i<n; i++)
+        {
+            popped[i] = pop();
+        }
+        return (T[])popped;
+    }
+    public T[] pollN(int n)
+    {
+        Object[] polled = new Object[n];
+        for(int i = 0; i<n; i++)
+        {
+            polled[i] = poll();
+        }
+        return (T[])polled;
+    }
+    public T poll() {
+        if (qIdx == data.length) {
+            if (sIdx >= 0) {
+                qIdx = 0;
+            } else {
+                return null;
+            }
+        }
+        T val = (T) data[qIdx];
+        data[qIdx++] = null;
+        if (qIdx == sIdx + 1) {
+            sIdx = -1;
+            qIdx = data.length;
+        }
+        return val;
+    }
+
+    public T removeFirst() {
+        checkIfEmpty();
+        T val = (T) data[qIdx];
+        data[qIdx--] = null;
+        return val;
+    }
+
+    public T removeLast() {
+        checkIfEmpty();
+        T val = (T) data[sIdx];
+        data[sIdx--] = null;
+        return val;
+    }
+
+    public T peek() {
+        checkIfEmpty();
+        T val = (T) data[sIdx];
+        return val;
+    }
+
+    private void checkIfEmpty() {
+        if (sIdx < 0) {
+            throw new EmptyStackException();
+        }
+    }
+
+    private int getSize() {
+        return sIdx + 1 + data.length - qIdx;
+    }
+
+    private boolean isEmpty() {
+        return sIdx >= 0 || qIdx < data.length;
+    }
+
+    private void clear() {
+        data = new Object[8];
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        for (int i = 0; i < data.length; i++) {
+            sb.append(data[i] != null ? data[i].toString() : "null").append(", ");
+        }
+        sb.setCharAt(sb.length() - 2, ']');
+        sb.setLength(sb.length() - 1);
+        return sb.toString();
+    }
+
+    public static void main(String[] args) {
+        var deq = new DequeS<Integer>();
+        deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
+        System.out.println(deq);
+        deq.pop();
+        deq.pop();
+        deq.pop();
+        deq.pop();
+        deq.pop();
+        deq.pop();
+        deq.pop();
+        System.out.println(deq);
+        System.out.println(deq.pop());
+        deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
+        System.out.println(deq);
+        deq.pollN(7);
+        System.out.println(deq.poll());
+        deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
+        System.out.println(deq);
+    }
+}

--- a/src/main/java/algorithms/datastructures/DequeS.java
+++ b/src/main/java/algorithms/datastructures/DequeS.java
@@ -4,10 +4,10 @@ import java.util.EmptyStackException;
 
 public class DequeS<T> {
 
-    private Object[] data;
+    protected Object[] data;
     private static final int EXPANSION_SIZE = 2;
-    private int sIdx = -1;
-    private int qIdx = 8;
+    protected int sIdx = -1;
+    protected int qIdx = 8;
 
     public DequeS() {
         data = new Object[8];
@@ -93,17 +93,25 @@ public class DequeS<T> {
         return val;
     }
 
-    public T[] popN(int n) {
-        Object[] popped = new Object[n];
-        for (int i = 0; i < n; i++) {
+    public T[] popN(final int N) {
+        if (getSize() < N) {
+            throw new EmptyStackException();
+        }
+
+        Object[] popped = new Object[N];
+        for (int i = 0; i < N; i++) {
             popped[i] = pop();
         }
         return (T[]) popped;
     }
 
-    public T[] pollN(int n) {
-        Object[] polled = new Object[n];
-        for (int i = 0; i < n; i++) {
+    public T[] pollN(final int N) {
+        if (getSize() < N) {
+            throw new EmptyStackException();
+        }
+
+        Object[] polled = new Object[N];
+        for (int i = 0; i < N; i++) {
             polled[i] = poll();
         }
         return (T[]) polled;
@@ -125,7 +133,7 @@ public class DequeS<T> {
         return val;
     }
 
-    private int getSize() {
+    public int getSize() {
         if (sIdx >= qIdx) {
             return sIdx - qIdx + 1;
         } else {
@@ -134,7 +142,7 @@ public class DequeS<T> {
     }
 
     private boolean isEmpty() {
-        return sIdx >= 0 || qIdx < data.length;
+        return sIdx == -1;
     }
 
     private void clear() {
@@ -142,11 +150,25 @@ public class DequeS<T> {
     }
 
     public String toString() {
+        if (isEmpty()) {
+            return "[]";
+        }
         StringBuilder sb = new StringBuilder();
         sb.append('[');
-        for (int i = 0; i < data.length; i++) {
-            sb.append(data[i] != null ? data[i].toString() : "null").append(", ");
+        
+        if (sIdx >= qIdx) {
+            for (int i = qIdx; i <= sIdx; i++) {
+                sb.append(data[i] != null ? data[i].toString() : "null").append(", ");
+            }
+        } else {
+            for (int i = qIdx; i < data.length; i++) {
+                sb.append(data[i] != null ? data[i].toString() : "null").append(", ");
+            }
+            for (int i = 0; i <= sIdx; i++) {
+                sb.append(data[i] != null ? data[i].toString() : "null").append(", ");
+            }
         }
+
         sb.setCharAt(sb.length() - 2, ']');
         sb.setLength(sb.length() - 1);
         return sb.toString();
@@ -157,13 +179,7 @@ public class DequeS<T> {
         System.out.println(deq + " with size: " + deq.getSize());
         deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
         System.out.println(deq);
-        deq.pop();
-        deq.pop();
-        deq.pop();
-        deq.pop();
-        deq.pop();
-        deq.pop();
-        deq.pop();
+        deq.popN(7);
         System.out.println(deq + " with size: " + deq.getSize());
         System.out.println(deq.pop());
         deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);

--- a/src/main/java/algorithms/datastructures/DequeS.java
+++ b/src/main/java/algorithms/datastructures/DequeS.java
@@ -1,7 +1,6 @@
 package algorithms.datastructures;
 
 import java.util.EmptyStackException;
-import java.util.LinkedList;
 
 public class DequeS<T> {
 
@@ -51,7 +50,7 @@ public class DequeS<T> {
         for (int i = 1; i <= data.length - qIdx; i++) {
             newData[newData.length - i] = data[data.length - i];
         }
-        qIdx = newData.length - qIdx;
+        qIdx = newData.length - (data.length - qIdx);
 
         data = newData;
     }
@@ -69,30 +68,14 @@ public class DequeS<T> {
 
         T val = (T) data[sIdx];
         data[sIdx--] = null;
+
         if (qIdx == sIdx + 1) {
             sIdx = -1;
             qIdx = data.length;
         }
         return val;
     }
-    public T[] popN(int n)
-    {
-        Object[] popped = new Object[n];
-        for(int i = 0; i<n; i++)
-        {
-            popped[i] = pop();
-        }
-        return (T[])popped;
-    }
-    public T[] pollN(int n)
-    {
-        Object[] polled = new Object[n];
-        for(int i = 0; i<n; i++)
-        {
-            polled[i] = poll();
-        }
-        return (T[])polled;
-    }
+
     public T poll() {
         if (qIdx == data.length) {
             if (sIdx >= 0) {
@@ -110,34 +93,44 @@ public class DequeS<T> {
         return val;
     }
 
-    public T removeFirst() {
-        checkIfEmpty();
-        T val = (T) data[qIdx];
-        data[qIdx--] = null;
-        return val;
+    public T[] popN(int n) {
+        Object[] popped = new Object[n];
+        for (int i = 0; i < n; i++) {
+            popped[i] = pop();
+        }
+        return (T[]) popped;
     }
 
-    public T removeLast() {
-        checkIfEmpty();
-        T val = (T) data[sIdx];
-        data[sIdx--] = null;
-        return val;
+    public T[] pollN(int n) {
+        Object[] polled = new Object[n];
+        for (int i = 0; i < n; i++) {
+            polled[i] = poll();
+        }
+        return (T[]) polled;
     }
 
-    public T peek() {
-        checkIfEmpty();
-        T val = (T) data[sIdx];
-        return val;
-    }
-
-    private void checkIfEmpty() {
-        if (sIdx < 0) {
+    public T peekLast() {
+        if (isEmpty()) {
             throw new EmptyStackException();
         }
+        T val = (T) data[sIdx];
+        return val;
+    }
+
+    public T peekFirst() {
+        if (isEmpty()) {
+            throw new EmptyStackException();
+        }
+        T val = (T) data[qIdx];
+        return val;
     }
 
     private int getSize() {
-        return sIdx + 1 + data.length - qIdx;
+        if (sIdx >= qIdx) {
+            return sIdx - qIdx + 1;
+        } else {
+            return sIdx + 1 + data.length - qIdx;
+        }
     }
 
     private boolean isEmpty() {
@@ -161,6 +154,7 @@ public class DequeS<T> {
 
     public static void main(String[] args) {
         var deq = new DequeS<Integer>();
+        System.out.println(deq + " with size: " + deq.getSize());
         deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
         System.out.println(deq);
         deq.pop();
@@ -170,13 +164,13 @@ public class DequeS<T> {
         deq.pop();
         deq.pop();
         deq.pop();
-        System.out.println(deq);
+        System.out.println(deq + " with size: " + deq.getSize());
         System.out.println(deq.pop());
         deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
-        System.out.println(deq);
+        System.out.println(deq + " with size: " + deq.getSize());
         deq.pollN(7);
         System.out.println(deq.poll());
-        deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40);
-        System.out.println(deq);
+        deq.push(5).push(10).push(15).offer(20).offer(25).offer(30).offer(35).offer(40).push(27).offer(36);
+        System.out.println(deq + " with size: " + deq.getSize());
     }
 }

--- a/src/main/java/algorithms/datastructures/StackS.java
+++ b/src/main/java/algorithms/datastructures/StackS.java
@@ -1,0 +1,97 @@
+package algorithms.datastructures;
+
+import java.util.EmptyStackException;
+
+public class StackS<T> {
+
+    private Object[] data;
+    private static final int EXPANSION_SIZE = 2;
+    private int idx = -1;
+
+    public StackS() {
+        data = new Object[8];
+    }
+
+    public StackS(int initialCapacity) {
+        data = new Object[initialCapacity];
+    }
+
+    public StackS<T> push(T val) {
+        if (idx == data.length - 1) {
+            expandSize();
+        }
+        data[++idx] = val;
+        return this;
+    }
+
+    private void expandSize() {
+        Object[] newData = new Object[data.length * EXPANSION_SIZE];
+        for (int i = 0; i < data.length; i++) {
+            newData[i] = data[i];
+        }
+        data = newData;
+    }
+
+    public T pop() {
+        if (idx < 0) {
+            return null;
+        }
+        T val = (T) data[idx];
+        data[idx--] = null;
+        return val;
+    }
+
+    public T remove() {
+        checkIfEmpty();
+        T val = (T) data[idx];
+        data[idx--] = null;
+        return val;
+    }
+
+    public T peek() {
+        checkIfEmpty();
+        T val = (T) data[idx];
+        data[idx] = null;
+        return val;
+    }
+
+    private void checkIfEmpty() {
+        if (idx < 0) {
+            throw new EmptyStackException();
+        }
+    }
+
+    private int getSize() {
+        return idx + 1;
+    }
+
+    private boolean isEmpty() {
+        return idx >= 0;
+    }
+
+    private void clear() {
+        data = new Object[8];
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        for (int i = 0; i <= idx; i++) {
+            sb.append(data[i].toString()).append(", ");
+        }
+        if (idx >= 0) {
+            sb.setCharAt(sb.length() - 2, ']');
+            sb.setLength(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    public static void main(String[] args) {
+        var s = new StackS<Integer>();
+        s.push(5);
+        s.push(10);
+        System.out.println(s.pop() + " : " + s.pop());
+        s.push(9).push(27).push(81);
+        System.out.println(s.toString() + " : " + s.pop());
+    }
+}


### PR DESCRIPTION
It's helpful to review these data structures that we use while solving algorithm problems. So, I have implemented these 3 structures in Java.

## Stack
The stack is pretty straightforward. We use an underlying array to store data and a number to keep the index we are at.  When we are pushing an element, we increment the index and put the given value to the data array at that index. When we are popping, we get the element at the index and decrement the index to the previous element. It is also helpful the set the element at the index to `null` before decrementing. `peek()` method gets the element at the index without decrementing it.

## Double-ended Queue with Array (Dequeue, Deque)
This data structure is more elaborate than the usual stack. It's helpful the think how a queue can be implemented using an array. As we are pushing to the beginning of the array in the stack, we would be enqueueing to the end of the array for a queue:
```
enqueue(9)
enqueue(18)
enqueue(27) 
data is [0, 0, 0, 0, 0, 27, 18, 9] // 0's stand for unassigned values
```
Combining this with array-stack would yield as a double-ended queue:
```
push(36)
push(45) 
push(54)
data is [36, 45, 54, 0, 0, 27, 18, 9]
```
If we start popping out elements, we would trivially pop out the first 3 elements. After that, the stack index would have to shift to the end of the array if the queue part is not empty.
```
pop_n_elements(3)
data is [0, 0, 0, 0, 0, 27, 18, 9]
pop()
data is [0, 0, 0, 0, 0, 27, 18, 0]
```
Same would happen with polling: 
```
poll_n_elements(3)
data is [36, 45, 54, 0, 0, 0, 0, 0]
poll()
data is [0, 45, 54, 0, 0, 0, 0, 0]
```
Unlike the directly linear structure of the stack, we won't expand the array when the stack index reaches the end or the queue index reaches the beginning, unless the queue part or the stack part is respectively empty. The emptiness of the stack or the queue parts can be checked by the stack index being at -1 or the queue index being at data length.
Here is how actual expansion happens:
```
data is [18, 27, 0, 36, 108, 144, 180, 72]
queue_index is 3
stack_index is 1
enqueue(45)
data is [18, 27, 45, 36, 108, 144, 180, 72] (queue_index is 2)
push(99) -> stack_index is 1 smaller than queue_index, which means that pushing would override the beginning element 
-> expand:
data is [18, 27, 99, 0, 0, 0, 0, 0, 0, 0, 45, 36, 108, 144, 180, 72]
queue_index is 11
stack_index is 2
```
We should also be able to poll elements that we push, and fill the empty indices at the beginning too:
```
data is [36, 45, 54, 0, 0, 0, 0, 0]
poll() // polls 36
data is [0, 45, 54, 0, 0, 0, 0, 0]
enqueue(18)
enqueue(27)
data is [18, 45, 54, 0, 0, 0, 0, 27]
```
Same happens with pushing:
```
data is [0, 0, 0, 0, 0, 27, 18, 0]
push(99)
enqueue(216)
data is [216, 0, 0, 0, 0, 27, 18, 99]
```
For this cyclical structure, we can take the modulo of the queue or stack index after incrementing or decrementing them.

## Array List
I've added this as it was really easy to add as the subclass of the deque. We only need to calculate the index corresponding to the list elements. Which is either some indices after the queue index or some indices (given index - queue elements at the end) before the stack index


I haven't added Iterator and equals() properties, because I think that the logic of these structures are enough for now.