### PR TITLE
527. Word Abbreviation

### DIFF
--- a/src/main/java/algorithms/curated170/hard/WordAbbreviation.java
+++ b/src/main/java/algorithms/curated170/hard/WordAbbreviation.java
@@ -1,0 +1,67 @@
+package algorithms.curated170.hard;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class WordAbbreviation {
+
+    public List<String> wordsAbbreviation(List<String> words) {
+        int len = words.size();
+        String[] res = new String[len];
+        int[] prefix = new int[len];
+        HashMap<String, List<Integer>> abbreviationIndices = new HashMap<>();
+
+        initializeAbbreviations(words, len, res, abbreviationIndices);
+
+        handleDuplicates(words, len, res, prefix, abbreviationIndices);
+
+        return Arrays.asList(res);
+    }
+
+    private void handleDuplicates(List<String> words, int len, String[] res, int[] prefix,
+            HashMap<String, List<Integer>> abbreviationIndices) {
+
+        for (int i = 0; i < len; i++) {
+            if (abbreviationIndices.get(res[i]).size() == 1) {
+                continue;
+            }
+            distributeNewAbbreviations(words, res, prefix, abbreviationIndices, i);
+            i--;
+        }
+    }
+
+    private void distributeNewAbbreviations(List<String> words, String[] res, int[] prefixLength,
+            HashMap<String, List<Integer>> abbreviationIndices, int i) {
+
+        List<Integer> indices = abbreviationIndices.get(res[i]);
+        abbreviationIndices.remove(res[i]);
+
+        for (int j : indices) {
+            prefixLength[j]++;
+            res[j] = makeAbbr(words.get(j), prefixLength[j]);
+            abbreviationIndices.putIfAbsent(res[j], new ArrayList<>());
+            abbreviationIndices.get(res[j]).add(j);
+        }
+    }
+
+    private void initializeAbbreviations(List<String> words, int len, String[] res,
+            HashMap<String, List<Integer>> abbreviationIndices) {
+        for (int i = 0; i < len; i++) {
+            res[i] = makeAbbr(words.get(i), 1);
+            abbreviationIndices.putIfAbsent(res[i], new ArrayList<>());
+            abbreviationIndices.get(res[i]).add(i);
+        }
+    }
+
+    private String makeAbbr(String s, int k) {
+        if (k >= s.length() - 2)
+            return s;
+        StringBuilder builder = new StringBuilder();
+        builder.append(s.substring(0, k));
+        builder.append(s.length() - 1 - k);
+        builder.append(s.charAt(s.length() - 1));
+        return builder.toString();
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/WordAbbreviation.java
+++ b/src/main/java/algorithms/curated170/hard/WordAbbreviation.java
@@ -9,59 +9,59 @@ public class WordAbbreviation {
 
     public List<String> wordsAbbreviation(List<String> words) {
         int len = words.size();
-        String[] res = new String[len];
-        int[] prefix = new int[len];
+        String[] abbr = new String[len];
+        int[] prefixLength = new int[len];
         HashMap<String, List<Integer>> abbreviationIndices = new HashMap<>();
 
-        initializeAbbreviations(words, len, res, abbreviationIndices);
+        initializeAbbreviations(words, len, abbr, abbreviationIndices);
 
-        handleDuplicates(words, len, res, prefix, abbreviationIndices);
+        handleDuplicates(words, len, abbr, prefixLength, abbreviationIndices);
 
-        return Arrays.asList(res);
+        return Arrays.asList(abbr);
     }
 
-    private void handleDuplicates(List<String> words, int len, String[] abbr, int[] prefix,
+    private void handleDuplicates(List<String> words, int len, String[] abbr, int[] prefixLength,
             HashMap<String, List<Integer>> abbreviationIndices) {
 
         for (int i = 0; i < len; i++) {
             if (abbreviationIndices.get(abbr[i]).size() == 1) {
                 continue;
             }
-            distributeNewAbbreviations(words, abbr, prefix, abbreviationIndices, i);
+            distributeNewAbbreviations(words, abbr, prefixLength, abbreviationIndices, i);
             i--;
         }
     }
 
-    private void distributeNewAbbreviations(List<String> words, String[] res, int[] prefixLength,
+    private void distributeNewAbbreviations(List<String> words, String[] abbr, int[] prefixLength,
             HashMap<String, List<Integer>> abbreviationIndices, int i) {
 
-        List<Integer> indices = abbreviationIndices.get(res[i]);
-        abbreviationIndices.remove(res[i]);
+        List<Integer> indices = abbreviationIndices.get(abbr[i]);
+        abbreviationIndices.remove(abbr[i]);
 
         for (int j : indices) {
             prefixLength[j]++;
-            res[j] = makeAbbr(words.get(j), prefixLength[j]);
-            abbreviationIndices.putIfAbsent(res[j], new ArrayList<>());
-            abbreviationIndices.get(res[j]).add(j);
+            abbr[j] = makeAbbr(words.get(j), prefixLength[j]);
+            abbreviationIndices.putIfAbsent(abbr[j], new ArrayList<>());
+            abbreviationIndices.get(abbr[j]).add(j);
         }
     }
 
-    private void initializeAbbreviations(List<String> words, int len, String[] res,
+    private void initializeAbbreviations(List<String> words, int len, String[] abbr,
             HashMap<String, List<Integer>> abbreviationIndices) {
         for (int i = 0; i < len; i++) {
-            res[i] = makeAbbr(words.get(i), 1);
-            abbreviationIndices.putIfAbsent(res[i], new ArrayList<>());
-            abbreviationIndices.get(res[i]).add(i);
+            abbr[i] = makeAbbr(words.get(i), 1);
+            abbreviationIndices.putIfAbsent(abbr[i], new ArrayList<>());
+            abbreviationIndices.get(abbr[i]).add(i);
         }
     }
 
     private String makeAbbr(String s, int k) {
         if (k >= s.length() - 2)
             return s;
-        StringBuilder builder = new StringBuilder();
-        builder.append(s.substring(0, k));
-        builder.append(s.length() - 1 - k);
-        builder.append(s.charAt(s.length() - 1));
-        return builder.toString();
+        StringBuilder abbreviation = new StringBuilder();
+        abbreviation.append(s.substring(0, k));
+        abbreviation.append(s.length() - 1 - k);
+        abbreviation.append(s.charAt(s.length() - 1));
+        return abbreviation.toString();
     }
 }

--- a/src/main/java/algorithms/curated170/hard/WordAbbreviation.java
+++ b/src/main/java/algorithms/curated170/hard/WordAbbreviation.java
@@ -20,14 +20,14 @@ public class WordAbbreviation {
         return Arrays.asList(res);
     }
 
-    private void handleDuplicates(List<String> words, int len, String[] res, int[] prefix,
+    private void handleDuplicates(List<String> words, int len, String[] abbr, int[] prefix,
             HashMap<String, List<Integer>> abbreviationIndices) {
 
         for (int i = 0; i < len; i++) {
-            if (abbreviationIndices.get(res[i]).size() == 1) {
+            if (abbreviationIndices.get(abbr[i]).size() == 1) {
                 continue;
             }
-            distributeNewAbbreviations(words, res, prefix, abbreviationIndices, i);
+            distributeNewAbbreviations(words, abbr, prefix, abbreviationIndices, i);
             i--;
         }
     }


### PR DESCRIPTION
Resolves: #214 

## Algorithm: 
In order to fix the duplicate abbreviation situation stated in the problem, we simply begin by abbreviating all the words as they would be without considering the other words. For each abbreviation, we put it as a key into a map and add the word that it is abbreviated from. Thus, this map stores which abbreviations correspond to which words, so we can see the duplicates.

After that, for each word, we check if the entry of its abbreviation in the map contains duplicate (its list having a size >1). If so, we distribute these words into new abbreviations by incrementing their prefix. For the words `"spiralgo"`, the old abbreviation "s6o" will become "sp5o". If a word like "smnbgfdo" had the same abbreviation "s6o", we would also remake it to "sm5o". After doing this re-abbreviating, we check the word again. If there are still duplicates (for example "spwwwwwo" becoming "sp5o" too) we reabbreviate again until there are no duplicates left, or we run out of letters. 