### PR TITLE
1548. The Most Similar Path in a Graph

### DIFF
--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraph.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraph.java
@@ -12,24 +12,6 @@ public class TheMostSimilarPathInAGraph {
     int targetLength;
     int[][] distancesAtCities;
 
-    private void calculateDistancesBackwards() {
-        String targetCity;
-        for (int t = targetLength - 2; t >= 0; t--) {
-            targetCity = targetPath[t];
-            for (int c = 0; c < n; c++) {
-                String curCity = names[c];
-                if (!curCity.equals(targetCity))
-                    distancesAtCities[t][c] = 1;
-                int minNextValue = Integer.MAX_VALUE;
-                for (int nextCity = 0; nextCity < n; nextCity++) {
-                    if (isAdjacent[nextCity][c] == true)
-                        minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
-                }
-                distancesAtCities[t][c] += minNextValue;
-            }
-        }
-    }
-
     public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
 
         this.n = n;
@@ -51,6 +33,41 @@ public class TheMostSimilarPathInAGraph {
         calculateDistancesBackwards();
 
         return evaluateMostSimilarPath();
+    }
+
+    private void setLastDistances() {
+        String targetCity = targetPath[targetLength - 1];
+        for (int i = 0; i < n; i++) {
+            String curCity = names[i];
+            if (!targetCity.equals(curCity)) {
+                distancesAtCities[targetLength - 1][i] = 1;
+            }
+        }
+    }
+
+    private void calculateDistancesBackwards() {
+        String targetCity;
+
+        for (int t = targetLength - 2; t >= 0; t--) {
+            targetCity = targetPath[t];
+
+            for (int c = 0; c < n; c++) {
+                String curCity = names[c];
+
+                if (!curCity.equals(targetCity)) {
+                    distancesAtCities[t][c] = 1;
+                }
+
+                int minNextValue = Integer.MAX_VALUE;
+                for (int nextCity = 0; nextCity < n; nextCity++) {
+                    if (isAdjacent[nextCity][c] == true) {
+                        minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
+                    }
+                }
+
+                distancesAtCities[t][c] += minNextValue;
+            }
+        }
     }
 
     private List<Integer> evaluateMostSimilarPath() {
@@ -92,15 +109,4 @@ public class TheMostSimilarPathInAGraph {
         mostSimilarPath.add(curMinCity);
         addNextVertices(mostSimilarPath, curMinCity, idx + 1);
     }
-
-    private void setLastDistances() {
-        String targetCity = targetPath[targetLength - 1];
-        for (int i = 0; i < n; i++) {
-            String curCity = names[i];
-            if (!targetCity.equals(curCity)) {
-                distancesAtCities[targetLength - 1][i] = 1;
-            }
-        }
-    }
-
 }

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraph.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraph.java
@@ -1,0 +1,92 @@
+package algorithms.curated170.hard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TheMostSimilarPathInAGraph {
+
+    public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
+
+        // Start with creating a graph based on the given roads. Mark 1 for each road
+        // pairs.
+        int[][] graph = new int[n][n];
+        for (int[] road : roads) {
+            int x = road[0];
+            int y = road[1];
+            graph[x][y] = graph[y][x] = 1;
+        }
+        // With this graph in mind, now let's look at the actual problem - we need to
+        // come up with a path that has least edit distance in comparison to the
+        // targetPath. So, if we know the minimum possible edit distance till a given
+        // index of the targetPath (say i), we will be able to compute the minimum
+        // possible edit distance till (i+1). The only catch here is that we have to
+        // check which nodes from ith column, can be used to calculate (i+1)th column
+        // for a given cell. We could find this from our initial graph.
+
+        int targetLength = targetPath.length;
+        int[][] distancesAtCities = new int[targetLength][n];
+        String targetCity = targetPath[targetLength - 1];
+        for (int i = 0; i < n; i++) {
+            String curCity = names[i];
+            if (!targetCity.equals(curCity))
+                distancesAtCities[targetLength - 1][i] = 1;
+        }
+        // The perspective is shifted from graph traversal to a DP optimization.
+
+        for (int t = targetLength - 2; t >= 0; t--) {
+            targetCity = targetPath[t];
+            for (int c = 0; c < n; c++) {
+                String curCity = names[c];
+                if (!curCity.equals(targetCity))
+                    distancesAtCities[t][c] = 1;
+                int minNextValue = Integer.MAX_VALUE;
+                for (int nextCity = 0; nextCity < n; nextCity++) {
+                    if (graph[nextCity][c] == 1)
+                        minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
+                }
+                distancesAtCities[t][c] += minNextValue;
+            }
+        }
+        /*
+         * Once we computed the DP matrix bottom, we have to build our solution top
+         * down. Once again we traverse our DP matrix starting with row 0 and find the
+         * index which gives us the minimum edit distance. We store it in prevInd
+         * variable. From there, we find out the node which is connected to the previous
+         * node and has the minimum edit distance. We add this to our output. Update our
+         * prevInd to the current minimum index (curMinInd). Keep repeating step 7 till
+         * we reach the end of the target path.
+         */
+
+        List<Integer> mostSimilarPath = new ArrayList<>(targetLength);
+        int prevCity = 0;
+
+        for (int i = 1; i < n; i++) {
+            if (distancesAtCities[0][i] < distancesAtCities[0][prevCity]) {
+                prevCity = i;
+            }
+        }
+        mostSimilarPath.add(prevCity);
+
+        for (int i = 1; i < targetLength; i++) {
+            int curMinIdx = -1;
+            int curMinDist = Integer.MAX_VALUE;
+
+            for (int nextCity = 0; nextCity < n; nextCity++) {
+                if (graph[nextCity][prevCity] != 1) {
+                    continue;
+                }
+
+                if (distancesAtCities[i][nextCity] < curMinDist) {
+                    curMinDist = distancesAtCities[i][nextCity];
+                    curMinIdx = nextCity;
+                }
+            }
+
+            mostSimilarPath.add(curMinIdx);
+            prevCity = curMinIdx;
+        }
+
+        return mostSimilarPath;
+    }
+
+}

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraph.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraph.java
@@ -5,34 +5,15 @@ import java.util.List;
 
 public class TheMostSimilarPathInAGraph {
 
-    public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
+    int n;
+    boolean[][] isAdjacent;
+    String[] names;
+    String[] targetPath;
+    int targetLength;
+    int[][] distancesAtCities;
 
-        // Start with creating a graph based on the given roads. Mark 1 for each road
-        // pairs.
-        int[][] graph = new int[n][n];
-        for (int[] road : roads) {
-            int x = road[0];
-            int y = road[1];
-            graph[x][y] = graph[y][x] = 1;
-        }
-        // With this graph in mind, now let's look at the actual problem - we need to
-        // come up with a path that has least edit distance in comparison to the
-        // targetPath. So, if we know the minimum possible edit distance till a given
-        // index of the targetPath (say i), we will be able to compute the minimum
-        // possible edit distance till (i+1). The only catch here is that we have to
-        // check which nodes from ith column, can be used to calculate (i+1)th column
-        // for a given cell. We could find this from our initial graph.
-
-        int targetLength = targetPath.length;
-        int[][] distancesAtCities = new int[targetLength][n];
-        String targetCity = targetPath[targetLength - 1];
-        for (int i = 0; i < n; i++) {
-            String curCity = names[i];
-            if (!targetCity.equals(curCity))
-                distancesAtCities[targetLength - 1][i] = 1;
-        }
-        // The perspective is shifted from graph traversal to a DP optimization.
-
+    private void calculateDistancesBackwards() {
+        String targetCity;
         for (int t = targetLength - 2; t >= 0; t--) {
             targetCity = targetPath[t];
             for (int c = 0; c < n; c++) {
@@ -41,22 +22,38 @@ public class TheMostSimilarPathInAGraph {
                     distancesAtCities[t][c] = 1;
                 int minNextValue = Integer.MAX_VALUE;
                 for (int nextCity = 0; nextCity < n; nextCity++) {
-                    if (graph[nextCity][c] == 1)
+                    if (isAdjacent[nextCity][c] == true)
                         minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
                 }
                 distancesAtCities[t][c] += minNextValue;
             }
         }
-        /*
-         * Once we computed the DP matrix bottom, we have to build our solution top
-         * down. Once again we traverse our DP matrix starting with row 0 and find the
-         * index which gives us the minimum edit distance. We store it in prevInd
-         * variable. From there, we find out the node which is connected to the previous
-         * node and has the minimum edit distance. We add this to our output. Update our
-         * prevInd to the current minimum index (curMinInd). Keep repeating step 7 till
-         * we reach the end of the target path.
-         */
+    }
 
+    public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
+
+        this.n = n;
+        this.names = names;
+        this.targetPath = targetPath;
+        isAdjacent = new boolean[n][n];
+
+        for (int[] road : roads) {
+            int x = road[0];
+            int y = road[1];
+            isAdjacent[x][y] = isAdjacent[y][x] = true;
+        }
+
+        targetLength = targetPath.length;
+        distancesAtCities = new int[targetLength][n];
+
+        setLastDistances();
+
+        calculateDistancesBackwards();
+
+        return evaluateMostSimilarPath();
+    }
+
+    private List<Integer> evaluateMostSimilarPath() {
         List<Integer> mostSimilarPath = new ArrayList<>(targetLength);
         int prevCity = 0;
 
@@ -67,26 +64,43 @@ public class TheMostSimilarPathInAGraph {
         }
         mostSimilarPath.add(prevCity);
 
-        for (int i = 1; i < targetLength; i++) {
-            int curMinIdx = -1;
-            int curMinDist = Integer.MAX_VALUE;
-
-            for (int nextCity = 0; nextCity < n; nextCity++) {
-                if (graph[nextCity][prevCity] != 1) {
-                    continue;
-                }
-
-                if (distancesAtCities[i][nextCity] < curMinDist) {
-                    curMinDist = distancesAtCities[i][nextCity];
-                    curMinIdx = nextCity;
-                }
-            }
-
-            mostSimilarPath.add(curMinIdx);
-            prevCity = curMinIdx;
-        }
+        addNextVertices(mostSimilarPath, prevCity, 1);
 
         return mostSimilarPath;
+    }
+
+    private void addNextVertices(List<Integer> mostSimilarPath, int prevCity, int idx) {
+
+        if (idx == targetLength) {
+            return;
+        }
+
+        int curMinCity = -1;
+        int curMinDist = Integer.MAX_VALUE;
+
+        for (int nextCity = 0; nextCity < n; nextCity++) {
+            if (isAdjacent[nextCity][prevCity] == false) {
+                continue;
+            }
+
+            if (distancesAtCities[idx][nextCity] < curMinDist) {
+                curMinDist = distancesAtCities[idx][nextCity];
+                curMinCity = nextCity;
+            }
+        }
+
+        mostSimilarPath.add(curMinCity);
+        addNextVertices(mostSimilarPath, curMinCity, idx + 1);
+    }
+
+    private void setLastDistances() {
+        String targetCity = targetPath[targetLength - 1];
+        for (int i = 0; i < n; i++) {
+            String curCity = names[i];
+            if (!targetCity.equals(curCity)) {
+                distancesAtCities[targetLength - 1][i] = 1;
+            }
+        }
     }
 
 }

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphDP.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphDP.java
@@ -4,40 +4,40 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TheMostSimilarPathInAGraphDP {
-    
+
     int n;
     String[] names;
     String[] targetPath;
     int targetLength;
     int[][] distancesAtCities;
     int[][] graph;
- 
+
     public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
- 
+
         this.n = n;
         this.names = names;
         this.targetPath = targetPath;
         graph = createGraph(n, roads);
-       
- 
+
         targetLength = targetPath.length;
         distancesAtCities = new int[targetLength][n];
- 
+
         setLastDistances();
- 
+
         calculateDistancesBackwards();
- 
+
         return evaluateMostSimilarPath();
     }
- private int[][] createGraph(int n, int[][] roads) {
+
+    private int[][] createGraph(int n, int[][] roads) {
         int[][] graph = new int[n][];
- 
+
         int[] adjacentCount = new int[n];
         for (int[] road : roads) {
             adjacentCount[road[0]]++;
             adjacentCount[road[1]]++;
         }
- 
+
         for (int i = 0; i < n; i++) {
             graph[i] = new int[adjacentCount[i]];
         }
@@ -48,6 +48,7 @@ public class TheMostSimilarPathInAGraphDP {
         }
         return graph;
     }
+
     private void setLastDistances() {
         String targetCity = targetPath[targetLength - 1];
         for (int i = 0; i < n; i++) {
@@ -57,68 +58,68 @@ public class TheMostSimilarPathInAGraphDP {
             }
         }
     }
- 
+
     private void calculateDistancesBackwards() {
         String targetCity;
- 
+
         for (int t = targetLength - 2; t >= 0; t--) {
             targetCity = targetPath[t];
- 
+
             for (int c = 0; c < n; c++) {
                 String curCity = names[c];
- 
+
                 if (!curCity.equals(targetCity)) {
                     distancesAtCities[t][c] = 1;
                 }
-             
+
                 int minNextValue = Integer.MAX_VALUE;
-             
+
                 for (int nextCity : graph[c]) {
-                    
-                        minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
-                    
+
+                    minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
+
                 }
- 
+
                 distancesAtCities[t][c] += minNextValue;
             }
         }
     }
- 
+
     private List<Integer> evaluateMostSimilarPath() {
         List<Integer> mostSimilarPath = new ArrayList<>(targetLength);
         int prevCity = 0;
- 
+
         for (int i = 1; i < n; i++) {
             if (distancesAtCities[0][i] < distancesAtCities[0][prevCity]) {
                 prevCity = i;
             }
         }
         mostSimilarPath.add(prevCity);
- 
+
         addNextVertices(mostSimilarPath, prevCity, 1);
- 
+
         return mostSimilarPath;
     }
- 
+
     private void addNextVertices(List<Integer> mostSimilarPath, int prevCity, int idx) {
- 
+
         if (idx == targetLength) {
             return;
         }
- 
+
         int curMinCity = -1;
         int curMinDist = Integer.MAX_VALUE;
- 
-          for (int nextCity : graph[prevCity]) {
- 
+
+        for (int nextCity : graph[prevCity]) {
+
             if (distancesAtCities[idx][nextCity] < curMinDist) {
                 curMinDist = distancesAtCities[idx][nextCity];
                 curMinCity = nextCity;
             }
         }
- 
+
         mostSimilarPath.add(curMinCity);
         addNextVertices(mostSimilarPath, curMinCity, idx + 1);
     }
- 
+
 }

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphDP.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphDP.java
@@ -3,38 +3,51 @@ package algorithms.curated170.hard;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TheMostSimilarPathInAGraph {
-
+public class TheMostSimilarPathInAGraphDP {
+    
     int n;
-    boolean[][] isAdjacent;
     String[] names;
     String[] targetPath;
     int targetLength;
     int[][] distancesAtCities;
-
+    int[][] graph;
+ 
     public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
-
+ 
         this.n = n;
         this.names = names;
         this.targetPath = targetPath;
-        isAdjacent = new boolean[n][n];
-
-        for (int[] road : roads) {
-            int x = road[0];
-            int y = road[1];
-            isAdjacent[x][y] = isAdjacent[y][x] = true;
-        }
-
+        graph = createGraph(n, roads);
+       
+ 
         targetLength = targetPath.length;
         distancesAtCities = new int[targetLength][n];
-
+ 
         setLastDistances();
-
+ 
         calculateDistancesBackwards();
-
+ 
         return evaluateMostSimilarPath();
     }
-
+ private int[][] createGraph(int n, int[][] roads) {
+        int[][] graph = new int[n][];
+ 
+        int[] adjacentCount = new int[n];
+        for (int[] road : roads) {
+            adjacentCount[road[0]]++;
+            adjacentCount[road[1]]++;
+        }
+ 
+        for (int i = 0; i < n; i++) {
+            graph[i] = new int[adjacentCount[i]];
+        }
+        int[] currIdx = new int[n];
+        for (int[] road : roads) {
+            graph[road[0]][currIdx[road[0]]++] = road[1];
+            graph[road[1]][currIdx[road[1]]++] = road[0];
+        }
+        return graph;
+    }
     private void setLastDistances() {
         String targetCity = targetPath[targetLength - 1];
         for (int i = 0; i < n; i++) {
@@ -44,69 +57,68 @@ public class TheMostSimilarPathInAGraph {
             }
         }
     }
-
+ 
     private void calculateDistancesBackwards() {
         String targetCity;
-
+ 
         for (int t = targetLength - 2; t >= 0; t--) {
             targetCity = targetPath[t];
-
+ 
             for (int c = 0; c < n; c++) {
                 String curCity = names[c];
-
+ 
                 if (!curCity.equals(targetCity)) {
                     distancesAtCities[t][c] = 1;
                 }
-
+             
                 int minNextValue = Integer.MAX_VALUE;
-                for (int nextCity = 0; nextCity < n; nextCity++) {
-                    if (isAdjacent[nextCity][c] == true) {
+             
+                for (int nextCity : graph[c]) {
+                    
                         minNextValue = Math.min(distancesAtCities[t + 1][nextCity], minNextValue);
-                    }
+                    
                 }
-
+ 
                 distancesAtCities[t][c] += minNextValue;
             }
         }
     }
-
+ 
     private List<Integer> evaluateMostSimilarPath() {
         List<Integer> mostSimilarPath = new ArrayList<>(targetLength);
         int prevCity = 0;
-
+ 
         for (int i = 1; i < n; i++) {
             if (distancesAtCities[0][i] < distancesAtCities[0][prevCity]) {
                 prevCity = i;
             }
         }
         mostSimilarPath.add(prevCity);
-
+ 
         addNextVertices(mostSimilarPath, prevCity, 1);
-
+ 
         return mostSimilarPath;
     }
-
+ 
     private void addNextVertices(List<Integer> mostSimilarPath, int prevCity, int idx) {
-
+ 
         if (idx == targetLength) {
             return;
         }
-
+ 
         int curMinCity = -1;
         int curMinDist = Integer.MAX_VALUE;
-
-        for (int nextCity = 0; nextCity < n; nextCity++) {
-            if (isAdjacent[nextCity][prevCity] == false) {
-                continue;
-            }
-
+ 
+          for (int nextCity : graph[prevCity]) {
+ 
             if (distancesAtCities[idx][nextCity] < curMinDist) {
                 curMinDist = distancesAtCities[idx][nextCity];
                 curMinCity = nextCity;
             }
         }
-
+ 
         mostSimilarPath.add(curMinCity);
         addNextVertices(mostSimilarPath, curMinCity, idx + 1);
     }
+ 
 }

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
@@ -33,28 +33,29 @@ public class TheMostSimilarPathInAGraphQueue {
         boolean[][] seen = new boolean[n][t];
         while (!paths.isEmpty()) {
             List<List<Integer>> path = paths.poll();
-            List<Integer> currCityDist = path.get(0);
-            List<Integer> currPath = path.get(1);
+            List<Integer> curCityAndDist = path.get(0);
+            List<Integer> currPathNodes = path.get(1);
 
-            int city = currCityDist.get(CITY), length = currCityDist.get(LENGTH);
+            int city = curCityAndDist.get(CITY), length = curCityAndDist.get(LENGTH);
             if (length == t - 1) {
-                return currPath;
+                return currPathNodes;
             }
 
-            List<Integer> nextPath;
+            List<Integer> nextPathNodes;
             for (int neighbor : graph[city]) {
                 if (seen[neighbor][length] == true) {
                     continue;
                 }
-
                 seen[neighbor][length] = true;
-                nextPath = new ArrayList<>(currPath);
-                nextPath.add(neighbor);
+
+                nextPathNodes = new ArrayList<>(currPathNodes);
+                nextPathNodes.add(neighbor);
+                List<List<Integer>> nextPath = List.of(List.of(neighbor, length + 1), nextPathNodes);
 
                 if (names[neighbor].equals(targetPath[length + 1])) {
-                    paths.addFirst(List.of(List.of(neighbor, length + 1), nextPath));
+                    paths.addFirst(nextPath);
                 } else {
-                    paths.addLast(List.of(List.of(neighbor, length + 1), nextPath));
+                    paths.addLast(nextPath);
                 }
             }
         }
@@ -86,9 +87,9 @@ public class TheMostSimilarPathInAGraphQueue {
             graph[i] = new int[adjacentCount[i]];
         }
         int[] currIdx = new int[n];
-        for (int[] edge : roads) {
-            graph[edge[0]][currIdx[edge[0]]++] = edge[1];
-            graph[edge[1]][currIdx[edge[1]]++] = edge[0];
+        for (int[] road : roads) {
+            graph[road[0]][currIdx[road[0]]++] = road[1];
+            graph[road[1]][currIdx[road[1]]++] = road[0];
         }
         return graph;
     }

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
@@ -1,0 +1,96 @@
+package algorithms.curated170.hard;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TheMostSimilarPathInAGraphQueue {
+
+    private static final int CITY = 0, LENGTH = 1;
+
+    public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
+        int t = targetPath.length;
+        if (t == 0) {
+            return new ArrayList<>();
+        }
+
+        int[][] graph = createGraph(n, roads);
+
+        Deque<List<List<Integer>>> paths = new ArrayDeque<>();
+
+        setPathStarts(n, names, targetPath, paths);
+
+        return buildPathWithQueue(graph, paths, names, targetPath, n);
+    }
+
+    private List<Integer> buildPathWithQueue(int[][] graph, Deque<List<List<Integer>>> paths, String[] names, String[] targetPath,
+            int n) {
+        int t = targetPath.length;
+
+        boolean[][] seen = new boolean[n][t];
+        while (!paths.isEmpty()) {
+            List<List<Integer>> path = paths.poll();
+            List<Integer> currCityDist = path.get(0);
+            List<Integer> currPath = path.get(1);
+
+            int city = currCityDist.get(CITY), length = currCityDist.get(LENGTH);
+            if (length == t - 1) {
+                return currPath;
+            }
+
+            List<Integer> nextPath;
+            for (int neighbor : graph[city]) {
+                if (seen[neighbor][length] == true) {
+                    continue;
+                }
+
+                seen[neighbor][length] = true;
+                nextPath = new ArrayList<>(currPath);
+                nextPath.add(neighbor);
+
+                if (names[neighbor].equals(targetPath[length + 1])) {
+                    paths.addFirst(List.of(List.of(neighbor, length + 1), nextPath));
+                } else {
+                    paths.addLast(List.of(List.of(neighbor, length + 1), nextPath));
+                }
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    private void setPathStarts(int n, String[] names, String[] targetPath, Deque<List<List<Integer>>> q) {
+        for (int i = 0; i < n; i++) {
+            List<Integer> list = new ArrayList<>();
+            list.add(i);
+            if (targetPath[0].equals(names[i])) {
+                q.addFirst(List.of(List.of(i, 0), list));
+            } else {
+                q.addLast(List.of(List.of(i, 0), list));
+            }
+        }
+    }
+
+    private int[][] createGraph(int n, int[][] roads) {
+        int[][] graph = new int[n][];
+
+        int[] adjacentCount = new int[n];
+        for (int[] road : roads) {
+            adjacentCount[road[0]]++;
+            adjacentCount[road[1]]++;
+        }
+
+        for (int i = 0; i < n; i++) {
+            graph[i] = new int[adjacentCount[i]];
+        }
+        int[] currIdx = new int[n];
+        for (int[] edge : roads) {
+            graph[edge[0]][currIdx[edge[0]]++] = edge[1];
+            graph[edge[1]][currIdx[edge[1]]++] = edge[0];
+        }
+        return graph;
+    }
+
+}

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
@@ -3,14 +3,10 @@ package algorithms.curated170.hard;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class TheMostSimilarPathInAGraphQueue {
-
-    private static final int CITY = 0, LENGTH = 1;
-
+    
     public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
         int t = targetPath.length;
         if (t == 0) {
@@ -19,30 +15,30 @@ public class TheMostSimilarPathInAGraphQueue {
 
         int[][] graph = createGraph(n, roads);
 
-        Deque<List<List<Integer>>> paths = new ArrayDeque<>();
+        Deque<Path> paths = new ArrayDeque<>();
 
         setPathStarts(n, names, targetPath, paths);
 
         return buildPathWithQueue(graph, paths, names, targetPath, n);
     }
 
-    private List<Integer> buildPathWithQueue(int[][] graph, Deque<List<List<Integer>>> paths, String[] names, String[] targetPath,
+    private List<Integer> buildPathWithQueue(int[][] graph, Deque<Path> paths, String[] names, String[] targetPath,
             int n) {
         int t = targetPath.length;
 
         boolean[][] seen = new boolean[n][t];
         while (!paths.isEmpty()) {
-            List<List<Integer>> path = paths.poll();
-            List<Integer> curCityAndDist = path.get(0);
-            List<Integer> currPathNodes = path.get(1);
+            Path city = paths.poll();
+            List<Integer> currPathNodes = city.currPathNodes;
 
-            int city = curCityAndDist.get(CITY), length = curCityAndDist.get(LENGTH);
-            if (length == t - 1) {
+            int length = currPathNodes.size();
+
+            if (length == t) {
                 return currPathNodes;
             }
 
             List<Integer> nextPathNodes;
-            for (int neighbor : graph[city]) {
+            for (int neighbor : graph[city.cityIndex]) {
                 if (seen[neighbor][length] == true) {
                     continue;
                 }
@@ -50,9 +46,10 @@ public class TheMostSimilarPathInAGraphQueue {
 
                 nextPathNodes = new ArrayList<>(currPathNodes);
                 nextPathNodes.add(neighbor);
-                List<List<Integer>> nextPath = List.of(List.of(neighbor, length + 1), nextPathNodes);
 
-                if (names[neighbor].equals(targetPath[length + 1])) {
+                Path nextPath = new Path(neighbor, nextPathNodes);
+
+                if (names[neighbor].equals(targetPath[length])) {
                     paths.addFirst(nextPath);
                 } else {
                     paths.addLast(nextPath);
@@ -62,14 +59,15 @@ public class TheMostSimilarPathInAGraphQueue {
         return new ArrayList<>();
     }
 
-    private void setPathStarts(int n, String[] names, String[] targetPath, Deque<List<List<Integer>>> q) {
+    private void setPathStarts(int n, String[] names, String[] targetPath, Deque<Path> q) {
         for (int i = 0; i < n; i++) {
             List<Integer> list = new ArrayList<>();
             list.add(i);
+            Path initialCity = new Path(i, list);
             if (targetPath[0].equals(names[i])) {
-                q.addFirst(List.of(List.of(i, 0), list));
+                q.addFirst(initialCity);
             } else {
-                q.addLast(List.of(List.of(i, 0), list));
+                q.addLast(initialCity);
             }
         }
     }
@@ -92,6 +90,16 @@ public class TheMostSimilarPathInAGraphQueue {
             graph[road[1]][currIdx[road[1]]++] = road[0];
         }
         return graph;
+    }
+
+    private class Path {
+        Path(int cityIndex, List<Integer> currPathNodes) {
+            this.cityIndex = cityIndex;
+            this.currPathNodes = currPathNodes;
+        }
+
+        int cityIndex;
+        List<Integer> currPathNodes;
     }
 
 }

--- a/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
+++ b/src/main/java/algorithms/curated170/hard/TheMostSimilarPathInAGraphQueue.java
@@ -6,7 +6,7 @@ import java.util.Deque;
 import java.util.List;
 
 public class TheMostSimilarPathInAGraphQueue {
-    
+
     public List<Integer> mostSimilar(int n, int[][] roads, String[] names, String[] targetPath) {
         int t = targetPath.length;
         if (t == 0) {


### PR DESCRIPTION
Resolves: #215 

## Approach 1-Dynamic Programming:
We should notice the recurrence relation:
The most similar path of length `T` is the concatenation of some city `c==targetPath[0]` and the most similar path that can start from that city, of length `T-1`.
Written in dynamic programming form:
`dp[t][c] = min{dp[t+1][next]} + targetPath[t] == c ? 0 : 1`, where `t` is the index of the target path we are considering and `next`∈ All cities connected to `c`.
We can first calculate `dp[lastIndex][c]` for all cities. `dp[lastIndex-1][c]` would then be equal to minimum of `dp[lastIndex][next]` for all cities connected `c` (of course, added with 1 or 0 for the edit distance). We can thus loop our way back to the 0th index. 

After that, we create the path simply by retracing the dp array with the minimum values and the previous city we visited.

## Approach 2-Priority Queue Implemented with Double-ended Queue:
Here, it is naturally intuitive to place all the paths in a priority queue and keep poll out the one with the least edit distance.  However, since we are allowed to return back to the same node after visiting it, this approach would render inefficient with a possible worst case complexity of `O(p·log p)`, `p=number of paths`. We won't get the benefits that an algorithm like Dijkstra's would have, as we can't have anything like distance array. So, the most convenient option is to use a dequeue as a sort of a priority queue. Each time, if some node on the path is equal to its corresponding name in the `targetPath`, we put its new path on the start of the queue, else we put it to the end of the queue. We remove paths from the queue by removing the first element, so the relatively best path. At the end, we would poll out the path with the length of the `targetPath` that is the most similar. I won't try to prove this, it's however pretty intuitive.