### PR TITLE
1216. Valid Palindrome III

### DIFF
--- a/src/main/java/algorithms/curated170/hard/ValidPalindromeIII.java
+++ b/src/main/java/algorithms/curated170/hard/ValidPalindromeIII.java
@@ -1,22 +1,37 @@
 package algorithms.curated170.hard;
 
-public class HandshakesThatDontCross {
+import java.util.Arrays;
+
+public class ValidPalindromeIII {
+    
     public boolean isValidPalindrome(String s, int k) {
+        int len = s.length();
         char[] data = s.toCharArray();
-        int[] dp = new int[data.length];
-        Arrays.fill(dp, 1);
-        int res = 1;
-        for (int i = 0; i < dp.length; i++ ) {
-            int maxSoFar = 0;
+        int[] maxPalindromicSubsequences = new int[len];
+        Arrays.fill(maxPalindromicSubsequences, 1);
+        int maxPalindrome = 1;
+
+        for (int i = 0; i < len; i++) {
+            int maxSubseqBetween = 0;
             for (int j = i - 1; j >= 0; j--) {
-                int temp = dp[j];
+                int subseqLength = maxPalindromicSubsequences[j];
+
                 if (data[i] == data[j]) {
-                    dp[j] = maxSoFar + 2;
-                    res = Math.max(res, dp[j]);
+                    maxPalindromicSubsequences[j] = maxSubseqBetween + 2;
+                    maxPalindrome = Math.max(maxPalindrome, maxPalindromicSubsequences[j]);
                 }
-                maxSoFar = Math.max(temp, maxSoFar);
+
+                maxSubseqBetween = Math.max(subseqLength, maxSubseqBetween);
             }
         }
-        return s.length() - k <= res;
+
+        return maxPalindrome >= len - k;
+    }
+
+    public static void main(String[] args) {
+        var solution = new ValidPalindromeIII();
+
+        System.out.println(solution.isValidPalindrome("sqreparqs", 2)); // true
+        System.out.println(solution.isValidPalindrome("sqreparqsf", 2)); // false
     }
 }

--- a/src/main/java/algorithms/curated170/hard/ValidPalindromeIII.java
+++ b/src/main/java/algorithms/curated170/hard/ValidPalindromeIII.java
@@ -1,0 +1,22 @@
+package algorithms.curated170.hard;
+
+public class HandshakesThatDontCross {
+    public boolean isValidPalindrome(String s, int k) {
+        char[] data = s.toCharArray();
+        int[] dp = new int[data.length];
+        Arrays.fill(dp, 1);
+        int res = 1;
+        for (int i = 0; i < dp.length; i++ ) {
+            int maxSoFar = 0;
+            for (int j = i - 1; j >= 0; j--) {
+                int temp = dp[j];
+                if (data[i] == data[j]) {
+                    dp[j] = maxSoFar + 2;
+                    res = Math.max(res, dp[j]);
+                }
+                maxSoFar = Math.max(temp, maxSoFar);
+            }
+        }
+        return s.length() - k <= res;
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/ValidPalindromeIII.java
+++ b/src/main/java/algorithms/curated170/hard/ValidPalindromeIII.java
@@ -11,7 +11,7 @@ public class ValidPalindromeIII {
         Arrays.fill(maxPalindromicSubsequences, 1);
         int maxPalindrome = 1;
 
-        for (int i = 0; i < len; i++) {
+        for (int i = 1; i < len; i++) {
             int maxSubseqBetween = 0;
             for (int j = i - 1; j >= 0; j--) {
                 int subseqLength = maxPalindromicSubsequences[j];


### PR DESCRIPTION
Resolves: #221 

## Algorithm:
Being able to remove some characters basically means that the palindrome does not have to be contiguous, a substring. It can thus be a subsequence. Our task is then to find the longest palindromic subsequence, and check if it's longer than the string size - k removed characters.

We can solve this problem using dynamic programming. Notice the sort of recursiveness here: the maximum palindromic subsequence length (`mpsl`) at some index `i` can be the maximum mspl starting at some index `j`. Or, if characters at these indices are equal, 2+mspl starting at some index `k, i>k>j`, mspl between i and j. It's the maximum of these two. 

We can easily derive a dp procedure from this. We pick some index and look for all indices before it. Initially the mspl-between is 0. And all mspl's for each index is 1. If two characters are equal, we increment the previous characters mspl to mspl-between+2. We check the global max each time. mspl-between is then updated to the previous value of the mspl of that previous index, we save it too in case it gets changed. 