### PR TITLE
317. Shortest Distance from All Buildings

### DIFF
--- a/src/main/java/algorithms/curated170/hard/ShortestDistanceFromAllBuildings.java
+++ b/src/main/java/algorithms/curated170/hard/ShortestDistanceFromAllBuildings.java
@@ -22,7 +22,7 @@ public class ShortestDistanceFromAllBuildings {
         for (int i = 0; i < m; i++)
             for (int j = 0; j < n; j++) {
                 if (grid[i][j] == 1) {
-                    minDist = helper(grid, i, j, visitCount, dist);
+                    minDist = BFS(grid, i, j, visitCount, dist);
                     if (minDist == Integer.MAX_VALUE)
                         return -1;
                     visitCount++;
@@ -32,7 +32,7 @@ public class ShortestDistanceFromAllBuildings {
         return minDist;
     }
 
-    private int helper(int[][] grid, int i, int j, int visitCount, int[][] dist) {
+    private int BFS(int[][] grid, int i, int j, int visitCount, int[][] dist) {
 
         int minDist = Integer.MAX_VALUE;
 

--- a/src/main/java/algorithms/curated170/hard/ShortestDistanceFromAllBuildings.java
+++ b/src/main/java/algorithms/curated170/hard/ShortestDistanceFromAllBuildings.java
@@ -1,53 +1,73 @@
 package algorithms.curated170.hard;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class ShortestDistanceFromAllBuildings {
 
-    int m, n;
-    int[][] grid;
-    int[][] count;
+    private static int[] dir = { -1, 0, 1, 0, -1 };
+
+    private int m, n;
 
     public int shortestDistance(int[][] grid) {
+
         m = grid.length;
         n = grid[0].length;
-        this.grid = grid;
-        count = new int[m][n];
 
-        for (int i = 0; i < m; i++) {
+        int visitCount = 0;
+        int minDist = 0;
+
+        int[][] dist = new int[m][n];
+
+        for (int i = 0; i < m; i++)
             for (int j = 0; j < n; j++) {
                 if (grid[i][j] == 1) {
-                    BFS(i, j, new int[m][n], 0);
+                    minDist = helper(grid, i, j, visitCount, dist);
+                    if (minDist == Integer.MAX_VALUE)
+                        return -1;
+                    visitCount++;
+                }
+            }
+
+        return minDist;
+    }
+
+    private int helper(int[][] grid, int i, int j, int visitCount, int[][] dist) {
+
+        int minDist = Integer.MAX_VALUE;
+
+        Deque<int[]> tiles = new ArrayDeque<>();
+        tiles.add(new int[] { i, j });
+        int layer = 0;
+
+        while (!tiles.isEmpty()) {
+            int levelSize = tiles.size();
+
+            layer++;
+            while (levelSize --> 0) {
+                int[] t = tiles.poll();
+
+                for (int k = 0; k < 4; k++) {
+                    int nx = t[0] + dir[k];
+                    int ny = t[1] + dir[k + 1];
+                    if (!outOfRangeOrVisited(nx, ny, grid, visitCount)) {
+                        dist[nx][ny] += layer;
+                        grid[nx][ny]--;
+                        tiles.add(new int[] { nx, ny });
+
+                        minDist = Math.min(minDist, dist[nx][ny]);
+                    }
                 }
             }
         }
-        int min = Integer.MAX_VALUE;
-        for (int i = 0; i < m; i++) {
-            for (int j = 0; j < n; j++) {
-                if (grid[i][j] == 0)
-                    min = Math.min(min, count[i][j]);
-            }
-        }
 
-        return min;
+        return minDist;
     }
 
-    void BFS(int a, int b, int[][] dist, int total) {
-        if (noVisit(a, b, dist, total)) {
-            return;
-        }
-        count[a][b] -= dist[a][b];
-        count[a][b] += (dist[a][b] = total);
+    private static final int INVERT_NEGATIVE_COUNT = -1;
 
-        BFS(a + 1, b, dist, total + 1);
-        BFS(a - 1, b, dist, total + 1);
-        BFS(a, b + 1, dist, total + 1);
-        BFS(a, b - 1, dist, total + 1);
-    }
-
-    private boolean noVisit(int a, int b, int[][] dist, int total) {
-        return a == m || a == -1 || b == -1 || b == n || grid[a][b] != 0 || (dist[a][b] != 0 &&  dist[a][b] < total);
+    private boolean outOfRangeOrVisited(int nx, int ny, int[][] grid, int visitCount) {
+        return nx == m || nx == -1 || ny == -1 || ny == n || INVERT_NEGATIVE_COUNT * grid[nx][ny] != visitCount;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/algorithms/curated170/hard/ShortestDistanceFromAllBuildings.java
+++ b/src/main/java/algorithms/curated170/hard/ShortestDistanceFromAllBuildings.java
@@ -1,0 +1,58 @@
+package algorithms.curated170.hard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShortestDistanceFromAllBuildings {
+
+    int m, n;
+    int[][] grid;
+    int[][] count;
+
+    public int shortestDistance(int[][] grid) {
+        m = grid.length;
+        n = grid[0].length;
+        this.grid = grid;
+        count = new int[m][n];
+
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                if (grid[i][j] == 1) {
+                    BFS(i, j, new int[m][n], 0);
+                }
+            }
+        }
+        int min = Integer.MAX_VALUE;
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                if (grid[i][j] == 0)
+                    min = Math.min(min, count[i][j]);
+            }
+        }
+
+        return min;
+    }
+
+    void BFS(int a, int b, int[][] dist, int total) {
+        if (noVisit(a, b, dist, total)) {
+            return;
+        }
+        count[a][b] -= dist[a][b];
+        count[a][b] += (dist[a][b] = total);
+
+        BFS(a + 1, b, dist, total + 1);
+        BFS(a - 1, b, dist, total + 1);
+        BFS(a, b + 1, dist, total + 1);
+        BFS(a, b - 1, dist, total + 1);
+    }
+
+    private boolean noVisit(int a, int b, int[][] dist, int total) {
+        return a == m || a == -1 || b == -1 || b == n || grid[a][b] != 0 || (dist[a][b] != 0 &&  dist[a][b] < total);
+    }
+
+    public static void main(String[] args) {
+        var solution = new ShortestDistanceFromAllBuildings();
+        int[][] grid = { { 1, 0, 2, 0, 1 }, { 0, 0, 0, 0, 0 }, { 0, 0, 1, 0, 0 } };
+        System.out.println(solution.shortestDistance(grid));
+    }
+}


### PR DESCRIPTION
Resolves: #230 

## Algorithm:
This is a pretty simple grid-BFS problem. To find the tile with minimum distance, we need to count the distances to tiles. We can count these distances by BFS'ing the whole grid at each building and summing up the tile distances in some matrix. Let'say that we have visited some tiles for some building. In some another building, if any tile around it can visit hasn't been visited by all the buildings before it, that means that there is no shortest distance for all buildings. This can be implemented by adding a check to the BFS, where this visit count property can hinder the process. We can also use the given space to count the visits in the given grid matrix. Eventually, we return the least distance we encountered for the last building.
 