### PR TITLE
307. Range Sum Query - Mutable & 308. Range Sum Query 2D - Mutable

### DIFF
--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutable.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutable.java
@@ -1,0 +1,11 @@
+package algorithms.curated170.hard.rangesumquery2dmutable;
+
+public class RangeSumQuery2DMutable {
+
+
+    
+
+    public static void main(String[] args) {
+
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutable.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutable.java
@@ -2,10 +2,43 @@ package algorithms.curated170.hard.rangesumquery2dmutable;
 
 public class RangeSumQuery2DMutable {
 
+    class NumMatrix {
+        
+        private int[][] colSums;
+        private int[][] matrix;
 
-    
+        public NumMatrix(int[][] matrix) {
+            this.matrix = matrix;
+            
+            int m = matrix.length;
+            int n = matrix[0].length;
+            colSums = new int[m + 1][n];
+            
+            for (int i = 1; i <= m; i++) {
+                for (int j = 0; j < n; j++) {
+                    colSums[i][j] = colSums[i - 1][j] + matrix[i - 1][j];
+                }
+            }
+        }
 
-    public static void main(String[] args) {
+        public void update(int row, int col, int val) {
+            for (int i = row + 1; i < colSums.length; i++) {
+                colSums[i][col] += (val - matrix[row][col]);
+            }
 
+            matrix[row][col] = val;
+        }
+
+
+        public int sumRegion(int row1, int col1, int row2, int col2) {
+            int sum = 0;
+
+            for (int j = col1; j <= col2; j++) {
+                sum += colSums[row2 + 1][j] - colSums[row1][j];
+            }
+
+            return sum;
+        }
     }
+
 }

--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutable.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutable.java
@@ -22,8 +22,10 @@ public class RangeSumQuery2DMutable {
         }
 
         public void update(int row, int col, int val) {
+            int diff = val - matrix[row][col];
+            
             for (int i = row + 1; i < colSums.length; i++) {
-                colSums[i][col] += (val - matrix[row][col]);
+                colSums[i][col] += diff;
             }
 
             matrix[row][col] = val;

--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableBIT.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableBIT.java
@@ -1,0 +1,82 @@
+package algorithms.curated170.hard.rangesumquery2dmutable;
+
+public class RangeSumQuery2DMutableBIT {
+
+    class NumMatrix {
+        
+        private int m;
+        private int n;
+        private int[][] bit;
+        private int[][] mat;
+
+        public NumMatrix(int[][] matrix) {
+            m = matrix.length;
+            n = matrix[0].length;
+            this.mat = matrix;
+
+            bit = new int[m + 1][];
+
+            for (int i = 1; i <= m; i++) {
+                bit[i] = new int[n + 1];
+            }
+
+            buildBIT(matrix);
+        }
+
+        public void update(int row, int col, int val) {
+            int oldVal = mat[row][col];
+            int diff = val - oldVal;
+            
+            updateBIT(row+1, col+1, diff);
+            mat[row][col] = val;
+        }
+
+        public int sumRegion(int row1, int col1, int row2, int col2) {
+
+            row1++;
+            col1++;
+            row2++;
+            col2++;
+
+            int a = queryBIT(row2, col2);
+            int b = queryBIT(row1 - 1, col1 - 1);
+            int c = queryBIT(row2, col1 - 1);
+            int d = queryBIT(row1 - 1, col2);
+
+            return (a + b) - (c + d);
+        }
+
+        private int lsb(int i) {
+            return i & (-i);
+        }
+
+        private void buildBIT(int[][] matrix) {
+            for (int i = 1; i <= m; i++) {
+                for (int j = 1; j <= n; j++) {
+                    int val = matrix[i - 1][j - 1];
+                    updateBIT(i, j, val);
+                }
+            }
+        }
+
+        private void updateBIT(int r, int c, int val) {
+            for (int i = r; i <= m; i += lsb(i)) {
+                for (int j = c; j <= n; j += lsb(j)) {
+                    bit[i][j] += val;
+                }
+            }
+        }
+
+        private int queryBIT(int r, int c) {
+            int sum = 0;
+
+            for (int i = r; i > 0; i -= lsb(i)) {
+                for (int j = c; j > 0; j -= lsb(j)) {
+                    sum += bit[i][j];
+                }
+            }
+
+            return sum;
+        }
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableSegmentTree.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableSegmentTree.java
@@ -1,0 +1,83 @@
+package algorithms.curated170.hard.rangesumquery2dmutable;
+
+public class RangeSumQuery2DMutableSegmentTree {
+
+    class NumMatrix {
+        private int m;
+        private int n;
+        private int[][] bit;
+
+        public NumMatrix(int[][] matrix) {
+            m = matrix.length;
+            n = matrix[0].length;
+
+            // Using 1-based indexing
+            bit = new int[m + 1][];
+
+            for (int i = 1; i <= m; i++) {
+                bit[i] = new int[n + 1];
+            }
+
+            buildBit(matrix);
+        }
+
+        public void update(int row, int col, int val) {
+            int oldVal = sumRegion(row, col, row, col);
+            int diff = val - oldVal;
+
+            // Increment for 1-based indexing
+            row++;
+            col++;
+
+            updateBit(row, col, diff);
+        }
+
+        public int sumRegion(int row1, int col1, int row2, int col2) {
+            // Increment for 1-based indexing
+            row1++;
+            col1++;
+            row2++;
+            col2++;
+
+            int a = queryBit(row2, col2);
+            int b = queryBit(row1 - 1, col1 - 1);
+            int c = queryBit(row2, col1 - 1);
+            int d = queryBit(row1 - 1, col2);
+
+            return (a + b) - (c + d);
+        }
+
+        private int lsb(int i) {
+            return i & (-i);
+        }
+
+        private void buildBit(int[][] matrix) {
+            for (int i = 1; i <= m; i++) {
+                for (int j = 1; j <= n; j++) {
+                    int val = matrix[i - 1][j - 1];
+                    updateBit(i, j, val);
+                }
+            }
+        }
+
+        private void updateBit(int r, int c, int val) {
+            for (int i = r; i <= m; i += lsb(i)) {
+                for (int j = c; j <= n; j += lsb(j)) {
+                    bit[i][j] += val;
+                }
+            }
+        }
+
+        private int queryBit(int r, int c) {
+            int sum = 0;
+
+            for (int i = r; i > 0; i -= lsb(i)) {
+                for (int j = c; j > 0; j -= lsb(j)) {
+                    sum += bit[i][j];
+                }
+            }
+
+            return sum;
+        }
+    }
+}

--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableSegmentTree.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableSegmentTree.java
@@ -1,78 +1,90 @@
 package algorithms.curated170.hard.rangesumquery2dmutable;
 
+import java.util.Arrays;
+
 public class RangeSumQuery2DMutableSegmentTree {
 
     class NumMatrix {
-        final int M, N;
-        int[][] segTree;
-        int[][] _matrix;
+        int[][] tree;
+        int m, n;
+
         public NumMatrix(int[][] matrix) {
-            M=matrix.length;
-            N=matrix[0].length;
-            this._matrix=matrix;
-            
-            segTree=new int[M][4*N];    
-            for(int i=0;i<M;i++){
-                insert(i,matrix[i],0,0,N-1);
+            m = matrix.length;
+            n = matrix[0].length;
+            tree = new int[m << 1][n << 1];
+            buildTree(matrix);
+        }
+
+        private void buildTree(int[][] mat) {
+            for (int i = m; i < (m << 1); i++) {
+                for (int j = n; j < (n << 1); j++) {
+                    tree[i][j] = mat[i - m][j - n];
+                }
+            }
+            for (int i = m - 1; i > 0; i--) {
+                for (int j = n; j < (n << 1); j++) {
+                    tree[i][j] = tree[2 * i][j] + tree[2 * i + 1][j];
+                }
+            }
+
+            for (int i = 1; i < (m << 1); i++) {
+                for (int j = n - 1; j > 0; j--) {
+                    tree[i][j] = tree[i][2 * j] + tree[i][2 * j + 1];
+                }
             }
         }
-        
-        private void insert(int segTreeNum, int[] arr,int treeIdx,int lo, int hi){
-            if(lo==hi){
-                segTree[segTreeNum][treeIdx]=arr[lo];
-                return;
-            }
-            int mid=lo+(hi-lo)/2;
-            insert(segTreeNum,arr,2*treeIdx+1,lo,mid);    
-            insert(segTreeNum,arr,2*treeIdx+2,mid+1,hi);
-            
-            segTree[segTreeNum][treeIdx]=segTree[segTreeNum][2*treeIdx+1]+segTree[segTreeNum][2*treeIdx+2];
-        }
-        
-        
-        private void update(int segTreeNum,int arrIdx,int treeIdx, int lo, int hi ){
-            if(lo==hi){
-                segTree[segTreeNum][treeIdx]=_matrix[segTreeNum][arrIdx];
-                return;
-            }
-            int mid=lo+(hi-lo)/2;
-            if(arrIdx<=mid){
-                update(segTreeNum,arrIdx,2*treeIdx+1,lo,mid);    
-            }else{
-                update(segTreeNum,arrIdx,2*treeIdx+2,mid+1,hi);
-            }
-            segTree[segTreeNum][treeIdx]=segTree[segTreeNum][2*treeIdx+1]+segTree[segTreeNum][2*treeIdx+2];
-        }
-        
+
         public void update(int row, int col, int val) {
-            _matrix[row][col]=val;
-            update(row,col,0,0,N-1);
-        }
-        
-        public int sumRegion(int row1, int col1, int row2, int col2) {
-            int ans=0;
-            for(int r = row1; r<=row2; r++){
-                ans+=query(r,0,0,N-1,col1,col2);
+            row += m;
+            col += n;
+
+            int i = row, j = col;
+            for (tree[i][j] = val; j > 0; j >>= 1) {
+                tree[i][j >> 1] = tree[i][j] + tree[i][j ^ 1];
             }
-            return ans;
-        }
-        
-        private int query(int segTreeNum,int treeIdx, int lo, int hi, int ql, int qr){
-            if(lo>qr||hi<ql){return 0;}
-            if(ql<=lo && qr>=hi){return segTree[segTreeNum][treeIdx];}
-            
-            int mid = lo+(hi-lo)/2;
-            
-            if(qr<=mid){
-                return query(segTreeNum,2*treeIdx+1,lo,mid,ql,qr); 
-            }else if(ql>mid){
-                return query(segTreeNum,2*treeIdx+2,mid+1,hi,ql,qr);
+
+            for (i = row >> 1; i > 0; i >>= 1) {
+                tree[i][col] = tree[i << 1 | 1][col] + tree[i << 1][col];
+                for (j = col; j > 0; j >>= 1) {
+                    tree[i][j >> 1] = tree[i][j] + tree[i][j ^ 1];
+                }
             }
-            
-            int left=query(segTreeNum,2*treeIdx+1,lo,mid,ql,mid);
-            int right=query(segTreeNum,2*treeIdx+2,mid+1,hi,mid+1,qr);
-            
-            return left+right;
         }
+
+        public int sumRegion(int row1, int c1, int row2, int c2) {
+            int sum = 0;
+            for (row1 += m, row2 += m; row1 <= row2; row1 >>= 1, row2 >>= 1) {
+                if ((row1 & 1) == 1) {
+                    sum += sumRange(row1, c1, c2);
+                    row1++;
+                }
+                if ((row2 & 1) == 0) {
+                    sum += sumRange(row2, c1, c2);
+                    row2--;
+                }
+            }
+            return sum;
+        }
+
+        private int sumRange(int r, int c1, int c2) {
+            int sum = 0;
+            for (c1 += n, c2 += n; c1 <= c2; c1 >>= 1, c2 >>= 1) {
+                if ((c1 & 1) == 1)
+                    sum += tree[r][c1++];
+                if ((c2 & 1) == 0)
+                    sum += tree[r][c2--];
+            }
+            return sum;
+        }
+    }
+
+    public static void main(String[] args) {
+        var solution = new RangeSumQuery2DMutableSegmentTree();
+
+        int[][] matrix = new int[][] { { 4, 7, 3, -1 }, { 2, 1, 9, 5 }, { -7, 3, 4, 0 }, { 8, 2, 1, 6 } };
+        var nm = solution.new NumMatrix(matrix);
+
+        nm.update(2, 1, 7);
+        System.out.println(nm.sumRegion(1, 1, 3, 2));
     }
 }

--- a/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableSegmentTree.java
+++ b/src/main/java/algorithms/curated170/hard/rangesumquery2dmutable/RangeSumQuery2DMutableSegmentTree.java
@@ -3,46 +3,45 @@ package algorithms.curated170.hard.rangesumquery2dmutable;
 public class RangeSumQuery2DMutableSegmentTree {
 
     class NumMatrix {
+        
         private int m;
         private int n;
         private int[][] bit;
+        private int[][] mat;
 
         public NumMatrix(int[][] matrix) {
             m = matrix.length;
             n = matrix[0].length;
+            this.mat = matrix;
 
-            // Using 1-based indexing
             bit = new int[m + 1][];
 
             for (int i = 1; i <= m; i++) {
                 bit[i] = new int[n + 1];
             }
 
-            buildBit(matrix);
+            buildBIT(matrix);
         }
 
         public void update(int row, int col, int val) {
-            int oldVal = sumRegion(row, col, row, col);
+            int oldVal = mat[row][col];
             int diff = val - oldVal;
-
-            // Increment for 1-based indexing
-            row++;
-            col++;
-
-            updateBit(row, col, diff);
+            
+            updateBIT(row+1, col+1, diff);
+            mat[row][col] = val;
         }
 
         public int sumRegion(int row1, int col1, int row2, int col2) {
-            // Increment for 1-based indexing
+
             row1++;
             col1++;
             row2++;
             col2++;
 
-            int a = queryBit(row2, col2);
-            int b = queryBit(row1 - 1, col1 - 1);
-            int c = queryBit(row2, col1 - 1);
-            int d = queryBit(row1 - 1, col2);
+            int a = queryBIT(row2, col2);
+            int b = queryBIT(row1 - 1, col1 - 1);
+            int c = queryBIT(row2, col1 - 1);
+            int d = queryBIT(row1 - 1, col2);
 
             return (a + b) - (c + d);
         }
@@ -51,16 +50,16 @@ public class RangeSumQuery2DMutableSegmentTree {
             return i & (-i);
         }
 
-        private void buildBit(int[][] matrix) {
+        private void buildBIT(int[][] matrix) {
             for (int i = 1; i <= m; i++) {
                 for (int j = 1; j <= n; j++) {
                     int val = matrix[i - 1][j - 1];
-                    updateBit(i, j, val);
+                    updateBIT(i, j, val);
                 }
             }
         }
 
-        private void updateBit(int r, int c, int val) {
+        private void updateBIT(int r, int c, int val) {
             for (int i = r; i <= m; i += lsb(i)) {
                 for (int j = c; j <= n; j += lsb(j)) {
                     bit[i][j] += val;
@@ -68,7 +67,7 @@ public class RangeSumQuery2DMutableSegmentTree {
             }
         }
 
-        private int queryBit(int r, int c) {
+        private int queryBIT(int r, int c) {
             int sum = 0;
 
             for (int i = r; i > 0; i -= lsb(i)) {

--- a/src/main/java/algorithms/medium/RangeSumQuery2DImmutable.java
+++ b/src/main/java/algorithms/medium/RangeSumQuery2DImmutable.java
@@ -1,0 +1,6 @@
+package algorithms.medium;
+
+public class RangeSumQuery2DImmutable {
+    
+}
+

--- a/src/main/java/algorithms/medium/RangeSumQuery2DImmutable.java
+++ b/src/main/java/algorithms/medium/RangeSumQuery2DImmutable.java
@@ -2,5 +2,25 @@ package algorithms.medium;
 
 public class RangeSumQuery2DImmutable {
     
-}
+    public class NumMatrix {
 
+        int[][] sum;
+
+        public NumMatrix(int[][] matrix) {
+
+            int rows = matrix.length, cols = matrix[0].length;
+            sum = new int[rows + 1][cols + 1];
+            for (int i = 1; i <= rows; i++) {
+                int rowSum = 0;
+                for (int j = 1; j <= cols; j++) {
+                    rowSum += matrix[i - 1][j - 1];
+                    sum[i][j] = rowSum + sum[i - 1][j];
+                }
+            }
+        }
+
+        public int sumRegion(int row1, int col1, int row2, int col2) {
+            return (sum[row2 + 1][col2 + 1] - sum[row1][col2 + 1] - sum[row2 + 1][col1] + sum[row1][col1]);
+        }
+    }
+}

--- a/src/main/java/algorithms/medium/RangeSumQueryMutable.java
+++ b/src/main/java/algorithms/medium/RangeSumQueryMutable.java
@@ -1,6 +1,0 @@
-package algorithms.medium;
-
-public class RangeSumQueryMutable {
-    
-}
-

--- a/src/main/java/algorithms/medium/RangeSumQueryMutable.java
+++ b/src/main/java/algorithms/medium/RangeSumQueryMutable.java
@@ -1,0 +1,6 @@
+package algorithms.medium;
+
+public class RangeSumQueryMutable {
+    
+}
+

--- a/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableBinaryIndexedTree.java
+++ b/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableBinaryIndexedTree.java
@@ -1,0 +1,20 @@
+package algorithms.medium.rangesumquerymutable;
+
+public class RangeSumQueryMutableBinaryIndexedTree {
+    class NumArray {
+
+        public NumArray(int[] nums) {
+            
+        }
+        
+        public void update(int index, int val) {
+            
+        }
+        
+        public int sumRange(int left, int right) {
+            return 0;
+        }
+    }
+    
+}
+

--- a/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableBinaryIndexedTree.java
+++ b/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableBinaryIndexedTree.java
@@ -1,20 +1,56 @@
 package algorithms.medium.rangesumquerymutable;
 
 public class RangeSumQueryMutableBinaryIndexedTree {
+
     class NumArray {
 
-        public NumArray(int[] nums) {
-            
-        }
-        
-        public void update(int index, int val) {
-            
-        }
-        
-        public int sumRange(int left, int right) {
-            return 0;
-        }
-    }
-    
-}
+        int[] bit;
+        int[] nums;
 
+        public NumArray(int[] nums) {
+            bit = nums.clone();
+            this.nums = nums;
+            buildTree();
+        }
+
+        private void buildTree() {
+            for (int i = 0; i < bit.length; i++) {
+                int j = i + lsb(i + 1);
+                if (j < bit.length) {
+                    bit[j] += bit[i];
+                }
+            }
+        }
+
+        private int lsb(int index) {
+            return index & -index;
+        }
+
+        public void update(int index, int val) {
+            add(index, val - nums[index]);
+            nums[index] = val;
+        }
+
+        private void add(int index, int val) {
+            while (index < bit.length) {
+                bit[index] += val;
+                index += lsb(index + 1);
+            }
+        }
+
+        private int prefixSum(int index) {
+            int prefixSum = 0;
+            while (index >= 0) {
+                prefixSum += bit[index];
+                index -= lsb(index + 1);
+            }
+            return prefixSum;
+        }
+
+        public int sumRange(int left, int right) {
+            return prefixSum(right) - prefixSum(left - 1);
+        }
+
+    }
+
+}

--- a/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableHalfNaive.java
+++ b/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableHalfNaive.java
@@ -1,0 +1,53 @@
+package algorithms.medium.rangesumquerymutable;
+
+public class RangeSumQueryMutableHalfNaive {
+
+    class NumArray {
+        int arr[];
+        int totalSum;
+
+        public NumArray(int[] nums) {
+            for (int i = 0; i < nums.length; i++)
+                totalSum += nums[i];
+
+            arr = nums;
+        }
+
+        public void update(int index, int val) {
+            totalSum += (val - arr[index]);
+            arr[index] = val;
+        }
+
+        public int sumRange(int left, int right) {
+            if (left == 0 && right + 1 == arr.length) {
+                return totalSum;
+            }
+
+            if (right - left < (arr.length >> 1)) {
+                return countValuesInRange(left, right);
+            }
+
+            return excludeValuesOutOfRange(left, right);
+        }
+
+        private int excludeValuesOutOfRange(int left, int right) {
+            int s = totalSum;
+            for (int i = 0; i < left; i++) {
+                s -= arr[i];
+            }
+            for (int i = arr.length - 1; i > right; i--) {
+                s -= arr[i];
+            }
+            return s;
+        }
+
+        private int countValuesInRange(int left, int right) {
+            int s = 0;
+            for (int i = left; i <= right; i++) {
+                s += arr[i];
+            }
+            return s;
+        }
+    }
+
+}

--- a/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableSegmentTree.java
+++ b/src/main/java/algorithms/medium/rangesumquerymutable/RangeSumQueryMutableSegmentTree.java
@@ -1,0 +1,42 @@
+package algorithms.medium.rangesumquerymutable;
+
+public class RangeSumQueryMutableSegmentTree {
+    class NumArray {
+        int[] tree;
+        int n;
+        
+        public NumArray(int[] nums) {
+            n = nums.length;
+            tree = new int[n << 1];
+            buildTree(nums);
+        }
+
+        private void buildTree(int[] nums) {
+            for (int i = n; i < (n << 1); i++) {
+                tree[i] = nums[i - n];
+            }
+
+            for (int i = n - 1; i > 0; i--) {
+                tree[i] = tree[i << 1] + tree[i << 1 | 1];
+            }
+        }
+
+        void update(int i, int val) {
+            for (tree[i += n] = val; i > 0; i >>= 1) {
+                tree[i >> 1] = tree[i] + tree[i ^ 1];
+            }
+        }
+
+        public int sumRange(int i, int j) {
+            int sum = 0;
+            for (i += n, j += n; i <= j; i >>= 1, j >>= 1) {
+                if ((i & 1) == 1)
+                    sum += tree[i++];
+                if ((j & 1) == 0)
+                    sum += tree[j--];
+            }
+            return sum;
+        }
+    }
+
+}


### PR DESCRIPTION
Problem: https://leetcode.com/problems/range-sum-query-mutable/

Here, the problem we face when we try to sum ranges using brute force range summing is that we cannot use prefix sums. If the range was immutable, it would have been a well choice. But reacting to the updates with prefix sums itself would have been inefficient. There are few ways of resolving this inconsistency between partial array sums and update/sum queries:

### Approach 1-Segment Trees
We could think of the range sums as a tree to some degree.
The root of the tree has the value `sum[0:length-1] = sum[0:mid]+sum[mid+1:length-1]`. Thus, each node in this range tree has a value equal to the sum of its 2 children. 
For the base case in the leaves of the tree, the value would be equal to `sum[i:i] = arr[i]`. Above the base case, for example at the node with the range 0:1, the value would be equal to the sum of the values of the children `= sum[0:0] + sum[1:1]`. Thus, after calculating the values of a node's children, we can calculate the nodes value. 

We can naturally implement this using custom classes and such, but that is inefficient. A more efficient implementation can be done through arrays.

- #### Build
Let's say that the root of the tree is located at the index 1. Then we can create a level-order tree where the next 2 indices are the children of the root at index 1, i.e. 2=left child, 3=right child. From this, we can infer that the second half of the tree array will consist of the base case values of individual indices. After defining these values, to continue building up in a bottom-up manner, we start at the index before the half, and the values as `tree[i] = tree[2*i] + tree[2*+1], 2*i = left child, 2*i+1 right child`. 
For `tree[]`, we naturally need an array of size `2*n` (n=array length).

- #### Range Sum Queries
Let `i` be the left index of the query, `j` the right.
Initially, we must add `n` to both i and j because their base cases are located `n` indices after their original array locations.

From the building of the tree array, we know that left children are located at even indices and right children at odds. 
This has two implications for i and j:

-- For `i`: If i is an even number, that means that we need to add the sum of its parent, not just the individual node's. If i is an odd number, that means that the value of the left child should be excluded, we only add the right child's value.
In the 1. case, we simply shift i to its parent index by dividing it by 2. In the 2. case, we add the right child's value. We then increment i. This would get us to the left node of the right sibling of the parent, whose value could be entirely add if `i≤j`.

-- For `j`: Likewise, if j is an odd number, that means that the node is a right child and the parent's range is included to be added. If j is an even number, this implies that the right child's value needs to be excluded. The procedure is symmetrical to the one done for `i`:
In the 1. case, we shift j to the parent index by dividing by 2 (integer division). In the 2. case, we add the left child's value. We then decrement i. This would get us to the right node of the left sibling of the parent, whose value could be entirely add if `i≤j`.

We do these 2 procedure together.

- #### Update Queries
This is pretty simple too. We first set tree[i+n] to the value, then update its parents values: tree[i/2] = tree[i] + tree[i^1]. The xor operation is a shortcut for using the left child if i is the right, or the right child if i is the left.