### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'zulu'
     - name: Build with Gradle
       run: ./gradlew build
 


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. 

According to AdoptOpenJDK:
24th July 2021: AdoptOpenJDK is moving to the Eclipse Foundation and rebranding.
Our July 2021 and future releases will come from Adoptium.net